### PR TITLE
8264256: Update version .jcheck/conf in jdk15u-dev to be 15.0.4

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,2 +1,28 @@
-project=jdk
-bugids=dup
+[general]
+project=jdk-updates
+jbs=JDK
+version=15.0.4
+
+[checks]
+error=author,committer,reviewers,issues,executable,symlink,message,hg-tag,whitespace
+
+[repository]
+tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
+branches=
+
+[census]
+version=0
+domain=openjdk.org
+
+[checks "whitespace"]
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
+
+[checks "reviewers"]
+reviewers=1
+ignore=duke
+
+[checks "committer"]
+role=committer
+
+[checks "issues"]
+pattern=^([124-8][0-9]{6}): (\S.*)$


### PR DESCRIPTION
Instruct updater script to use 15.0.4 release version from now on. 
Should integrate that no sooner than the version is created in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264256](https://bugs.openjdk.java.net/browse/JDK-8264256): Update version .jcheck/conf in jdk15u-dev to be 15.0.4


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/1/head:pull/1`
`$ git checkout pull/1`

To update a local copy of the PR:
`$ git checkout pull/1`
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/1/head`
