### PR TITLE
8257707: Fix incorrect format string in Http1HeaderParser

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http1HeaderParser.java
@@ -92,9 +92,9 @@ class Http1HeaderParser {
                 headerName = headerName.substring(0, headerName.indexOf(':')+1) + "...";
             msg = format("parsing HTTP/1.1 header, receiving [%s]", headerName);
         } else {
-            msg =format("HTTP/1.1 parser receiving [%s]", state, sb.toString());
+            msg = format("HTTP/1.1 parser receiving [%s]", sb.toString());
         }
-        return format("%s, parser state [%s]", msg , state);
+        return format("%s, parser state [%s]", msg, state);
     }
 
     /**


### PR DESCRIPTION
A follow-up to JDK-8204679. Tests run well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257707](https://bugs.openjdk.java.net/browse/JDK-8257707): Fix incorrect format string in Http1HeaderParser


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/5.diff">https://git.openjdk.java.net/jdk15u-dev/pull/5.diff</a>

</details>
