### PR TITLE
8240487: Cleanup whitespace in .cc, .hh, .m, and .mm files

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTSurfaceLayers.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTSurfaceLayers.m
@@ -108,7 +108,7 @@ JNF_COCOA_ENTER(env);
         CALayer *windowLayer = jlong_to_ptr(windowLayerPtr);
         surfaceLayers = [[AWTSurfaceLayers alloc] initWithWindowLayer: windowLayer];
     }];
-    
+
 JNF_COCOA_EXIT(env);
 
   return ptr_to_jlong(surfaceLayers);
@@ -125,7 +125,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformComponent_nativeSetBounds
 JNF_COCOA_ENTER(env);
 
   AWTSurfaceLayers *surfaceLayers = OBJC(surfaceLayersPtr);
-    
+
   [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
 
       CGRect rect = CGRectMake(x, y, width, height);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -545,11 +545,11 @@ static BOOL shouldUsePressAndHold() {
     if ((codePoint == 0x0024) || (codePoint == 0x00A3) ||
         (codePoint == 0x00A5) ||
         ((codePoint >= 0x20A3) && (codePoint <= 0x20BF)) ||
-	((codePoint >= 0x3000) && (codePoint <= 0x303F)) ||
+        ((codePoint >= 0x3000) && (codePoint <= 0x303F)) ||
         ((codePoint >= 0xFF00) && (codePoint <= 0xFFEF))) {
         // Code point is in 'CJK Symbols and Punctuation' or
         // 'Halfwidth and Fullwidth Forms' Unicode block or
-	// currency symbols unicode
+        // currency symbols unicode
         return YES;
     }
     return NO;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -25,7 +25,7 @@
 
 #import "CDataTransferer.h"
 #import "ThreadUtilities.h"
-#import "jni_util.h" 
+#import "jni_util.h"
 #import <Cocoa/Cocoa.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
@@ -79,10 +79,10 @@
 - (void)checkPasteboard:(id)sender {
 
     // This is called via NSApplicationDidBecomeActiveNotification.
-    
+
     // If the change count on the general pasteboard is different than when we set it
     // someone else put data on the clipboard.  That means the current owner lost ownership.
-    
+
     NSInteger newChangeCount = [[NSPasteboard generalPasteboard] changeCount];
 
     if (self.changeCount != newChangeCount) {
@@ -109,11 +109,11 @@
 
 - (BOOL) checkPasteboardWithoutNotification:(id)application {
     AWT_ASSERT_APPKIT_THREAD;
-    
+
     NSInteger newChangeCount = [[NSPasteboard generalPasteboard] changeCount];
-    
+
     if (self.changeCount != newChangeCount) {
-        self.changeCount = newChangeCount;    
+        self.changeCount = newChangeCount;
         return YES;
     } else {
         return NO;
@@ -189,7 +189,7 @@ JNF_COCOA_ENTER(env);
         dataTypes = [[[NSPasteboard generalPasteboard] types] retain];
     }];
     [dataTypes autorelease];
-    
+
     NSUInteger nFormats = [dataTypes count];
     NSUInteger knownFormats = 0;
     NSUInteger i;
@@ -250,7 +250,7 @@ JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
         clipData = [[[NSPasteboard generalPasteboard] dataForType:formatAsString] retain];
     }];
-    
+
     if (clipData == NULL) {
         [JNFException raise:env as:"java/io/IOException" reason:"Font transform has NaN position"];
         return NULL;
@@ -273,20 +273,20 @@ JNF_COCOA_EXIT(env);
     return returnValue;
 }
 
-/*                                                                                            
- * Class:     sun_lwawt_macosx_CClipboard                                                     
- * Method:    checkPasteboard                                                                 
- * Signature: ()V                                                                             
- */                                                                                           
+/*
+ * Class:     sun_lwawt_macosx_CClipboard
+ * Method:    checkPasteboard
+ * Signature: ()V
+ */
 JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CClipboard_checkPasteboardWithoutNotification
-(JNIEnv *env, jobject inObject)                                                               
-{                                                                                             
-    __block BOOL ret = NO;                                                                    
-    JNF_COCOA_ENTER(env);                                                                     
-    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){                                
-        ret = [[CClipboard sharedClipboard] checkPasteboardWithoutNotification:nil];          
-    }];                                                                                       
-                                                                                              
-    JNF_COCOA_EXIT(env);                                                                      
-    return ret;                                                                               
-}                                                                                             
+(JNIEnv *env, jobject inObject)
+{
+    __block BOOL ret = NO;
+    JNF_COCOA_ENTER(env);
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+        ret = [[CClipboard sharedClipboard] checkPasteboardWithoutNotification:nil];
+    }];
+
+    JNF_COCOA_EXIT(env);
+    return ret;
+}

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
@@ -611,7 +611,7 @@ extern JNFClassInfo jc_CDropTargetContextPeer;
         JNF_MEMBER_CACHE(handleExitMessageMethod, jc_CDropTargetContextPeer, "handleExitMessage", "(Ljava/awt/Component;J)V");
         if (sDraggingError == FALSE) {
             DLog3(@"  - dragExit: loc native %f, %f\n", sDraggingLocation.x, sDraggingLocation.y);
-             // AWT_THREADING Safe (CToolkitThreadBlockedHandler) 
+             // AWT_THREADING Safe (CToolkitThreadBlockedHandler)
             JNFCallVoidMethod(env, fDropTargetContextPeer,
                               handleExitMessageMethod, fComponent, ptr_to_jlong(self));
         }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CFRetainedResource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CFRetainedResource.m
@@ -39,7 +39,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CFRetainedResource_nativeCFRelease
 {
     if (releaseOnAppKitThread) {
         // Releasing resources on the main AppKit message loop only
-        // Releasing resources on the nested loops may cause dangling 
+        // Releasing resources on the nested loops may cause dangling
         // pointers after the nested loop is exited
         if ([NSApp respondsToSelector:@selector(postRunnableEvent:)]) {
             [NSApp postRunnableEvent:^() {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
@@ -112,7 +112,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromArra
     jlong result = 0L;
 
 JNF_COCOA_ENTER(env);
-    
+
     NSBitmapImageRep* imageRep = CImage_CreateImageRep(env, buffer, width, height);
     if (imageRep) {
         NSImage *nsImage = [[NSImage alloc] initWithSize:NSMakeSize(width, height)];
@@ -325,16 +325,16 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CImage_nativeResizeNSImageRepresent
 {
     if (!image) return;
     NSImage *i = (NSImage *)jlong_to_ptr(image);
-    
+
 JNF_COCOA_ENTER(env);
-    
+
     NSImageRep *imageRep = nil;
     NSArray *imageRepresentations = [i representations];
     NSEnumerator *imageEnumerator = [imageRepresentations objectEnumerator];
     while ((imageRep = [imageEnumerator nextObject]) != nil) {
         [imageRep setSize:NSMakeSize(w, h)];
     }
-    
+
 JNF_COCOA_EXIT(env);
 }
 
@@ -356,20 +356,20 @@ JNIEXPORT jobjectArray JNICALL
     NSImage *img = (NSImage *)jlong_to_ptr(image);
 
 JNF_COCOA_ENTER(env);
-        
+
     NSArray *imageRepresentations = [img representations];
     if([imageRepresentations count] == 0){
         return NULL;
     }
-    
+
     NSArray *sortedImageRepresentations = [imageRepresentations
                     sortedArrayUsingComparator: ^(id obj1, id obj2) {
-        
+
         NSImageRep *imageRep1 = (NSImageRep *) obj1;
         NSImageRep *imageRep2 = (NSImageRep *) obj2;
         NSSize size1 = [imageRep1 size];
         NSSize size2 = [imageRep2 size];
-        
+
         if (NSEqualSizes(size1, size2)) {
             return getOrder([imageRep1 pixelsWide] <= [imageRep2 pixelsWide] &&
                             [imageRep1 pixelsHigh] <= [imageRep2 pixelsHigh]);
@@ -380,7 +380,7 @@ JNF_COCOA_ENTER(env);
 
     NSMutableArray *sortedPixelSizes = [[[NSMutableArray alloc] init] autorelease];
     NSSize lastSize = [[sortedImageRepresentations lastObject] size];
-    
+
     NSUInteger i = [sortedImageRepresentations indexOfObjectPassingTest:
                ^BOOL(id obj, NSUInteger idx, BOOL *stop) {
         NSSize imageRepSize = [obj size];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
@@ -113,16 +113,16 @@
 }
 
 - (void) setJavaLabel:(NSString *)theLabel shortcut:(NSString *)theKeyEquivalent modifierMask:(jint)modifiers {
-    
+
     NSUInteger modifierMask = 0;
-    
+
     if (![theKeyEquivalent isEqualToString:@""]) {
         // Force the key equivalent to lower case if not using the shift key.
         // Otherwise AppKit will draw a Shift glyph in the menu.
         if ((modifiers & java_awt_event_KeyEvent_SHIFT_MASK) == 0) {
             theKeyEquivalent = [theKeyEquivalent lowercaseString];
         }
-        
+
         // Hack for the question mark -- SHIFT and / means use the question mark.
         if ((modifiers & java_awt_event_KeyEvent_SHIFT_MASK) != 0 &&
             [theKeyEquivalent isEqualToString:@"/"])
@@ -130,10 +130,10 @@
             theKeyEquivalent = @"?";
             modifiers &= ~java_awt_event_KeyEvent_SHIFT_MASK;
         }
-        
+
         modifierMask = JavaModifiersToNsKeyModifiers(modifiers, NO);
     }
-    
+
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         [fMenuItem setKeyEquivalent:theKeyEquivalent];
         [fMenuItem setKeyEquivalentModifierMask:modifierMask];
@@ -142,14 +142,14 @@
 }
 
 - (void) setJavaImage:(NSImage *)theImage {
-    
+
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [fMenuItem setImage:theImage];
     }];
 }
 
 - (void) setJavaToolTipText:(NSString *)theText {
-    
+
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [fMenuItem setToolTip:theText];
     }];
@@ -157,11 +157,11 @@
 
 
 - (void)setJavaEnabled:(BOOL) enabled {
-    
+
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         @synchronized(self) {
             fIsEnabled = enabled;
-            
+
             // Warning:  This won't work if the parent menu is disabled.
             // See [CMenu syncFromJava]. We still need to call it here so
             // the NSMenuItem itself gets properly updated.
@@ -171,7 +171,7 @@
 }
 
 - (BOOL)isEnabled {
-    
+
     BOOL enabled = NO;
     @synchronized(self) {
         enabled = fIsEnabled;
@@ -181,7 +181,7 @@
 
 
 - (void)setJavaState:(BOOL)newState {
-    
+
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [fMenuItem setState:(newState ? NSOnState : NSOffState)];
     }];
@@ -192,7 +192,7 @@
     [fMenuItem setTarget:nil];
     [fMenuItem release];
     fMenuItem = nil;
-    
+
     [super dealloc];
 }
 
@@ -217,7 +217,7 @@
 /** Convert a Java keycode for SetMenuItemCmd */
 static unichar AWTKeyToMacShortcut(jint awtKey, BOOL doShift) {
     unichar macKey = 0;
-    
+
     if ((awtKey >= java_awt_event_KeyEvent_VK_0 && awtKey <= java_awt_event_KeyEvent_VK_9) ||
         (awtKey >= java_awt_event_KeyEvent_VK_A && awtKey <= java_awt_event_KeyEvent_VK_Z))
     {
@@ -234,43 +234,43 @@ static unichar AWTKeyToMacShortcut(jint awtKey, BOOL doShift) {
         switch (awtKey) {
             case java_awt_event_KeyEvent_VK_BACK_QUOTE      : macKey = '`'; break;
             case java_awt_event_KeyEvent_VK_QUOTE           : macKey = '\''; break;
-                
+
             case java_awt_event_KeyEvent_VK_ESCAPE          : macKey = 0x1B; break;
             case java_awt_event_KeyEvent_VK_SPACE           : macKey = ' '; break;
             case java_awt_event_KeyEvent_VK_PAGE_UP         : macKey = NSPageUpFunctionKey; break;
             case java_awt_event_KeyEvent_VK_PAGE_DOWN       : macKey = NSPageDownFunctionKey; break;
             case java_awt_event_KeyEvent_VK_END             : macKey = NSEndFunctionKey; break;
             case java_awt_event_KeyEvent_VK_HOME            : macKey = NSHomeFunctionKey; break;
-                
+
             case java_awt_event_KeyEvent_VK_LEFT            : macKey = NSLeftArrowFunctionKey; break;
             case java_awt_event_KeyEvent_VK_UP              : macKey = NSUpArrowFunctionKey; break;
             case java_awt_event_KeyEvent_VK_RIGHT           : macKey = NSRightArrowFunctionKey; break;
             case java_awt_event_KeyEvent_VK_DOWN            : macKey = NSDownArrowFunctionKey; break;
-                
+
             case java_awt_event_KeyEvent_VK_COMMA           : macKey = ','; break;
-                
+
                 // Mac OS doesn't distinguish between the two '-' keys...
             case java_awt_event_KeyEvent_VK_MINUS           :
             case java_awt_event_KeyEvent_VK_SUBTRACT        : macKey = '-'; break;
-                
+
                 // or the two '.' keys...
             case java_awt_event_KeyEvent_VK_DECIMAL         :
             case java_awt_event_KeyEvent_VK_PERIOD          : macKey = '.'; break;
-                
+
                 // or the two '/' keys.
             case java_awt_event_KeyEvent_VK_DIVIDE          :
             case java_awt_event_KeyEvent_VK_SLASH           : macKey = '/'; break;
-                
+
             case java_awt_event_KeyEvent_VK_SEMICOLON       : macKey = ';'; break;
             case java_awt_event_KeyEvent_VK_EQUALS          : macKey = '='; break;
-                
+
             case java_awt_event_KeyEvent_VK_OPEN_BRACKET    : macKey = '['; break;
             case java_awt_event_KeyEvent_VK_BACK_SLASH      : macKey = '\\'; break;
             case java_awt_event_KeyEvent_VK_CLOSE_BRACKET   : macKey = ']'; break;
-                
+
             case java_awt_event_KeyEvent_VK_MULTIPLY        : macKey = '*'; break;
             case java_awt_event_KeyEvent_VK_ADD             : macKey = '+'; break;
-                
+
             case java_awt_event_KeyEvent_VK_HELP            : macKey = NSHelpFunctionKey; break;
             case java_awt_event_KeyEvent_VK_TAB             : macKey = NSTabCharacter; break;
             case java_awt_event_KeyEvent_VK_ENTER           : macKey = NSNewlineCharacter; break;
@@ -314,18 +314,18 @@ Java_sun_lwawt_macosx_CMenuItem_nativeSetLabel
     NSString *theLabel = JNFJavaToNSString(env, label);
     NSString *theKeyEquivalent = nil;
     unichar macKey = shortcutKey;
-    
+
     if (macKey == 0) {
         macKey = AWTKeyToMacShortcut(shortcutKeyCode, (mods & java_awt_event_KeyEvent_SHIFT_MASK) != 0);
     }
-    
+
     if (macKey != 0) {
         unichar equivalent[1] = {macKey};
         theKeyEquivalent = [NSString stringWithCharacters:equivalent length:1];
     } else {
         theKeyEquivalent = @"";
     }
-    
+
     [((CMenuItem *)jlong_to_ptr(menuItemObj)) setJavaLabel:theLabel shortcut:theKeyEquivalent modifierMask:mods];
     JNF_COCOA_EXIT(env);
 }
@@ -368,12 +368,12 @@ JNIEXPORT jlong JNICALL
 Java_sun_lwawt_macosx_CMenuItem_nativeCreate
 (JNIEnv *env, jobject peer, jlong parentCMenuObj, jboolean isSeparator)
 {
-    
+
     __block CMenuItem *aCMenuItem = nil;
     BOOL asSeparator = (isSeparator == JNI_TRUE) ? YES: NO;
     CMenu *parentCMenu = (CMenu *)jlong_to_ptr(parentCMenuObj);
     JNF_COCOA_ENTER(env);
-    
+
     jobject cPeerObjGlobal = (*env)->NewGlobalRef(env, peer);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
@@ -381,16 +381,16 @@ Java_sun_lwawt_macosx_CMenuItem_nativeCreate
                                          asSeparator: asSeparator];
         // the CMenuItem is released in CMenuComponent.dispose()
     }];
-    
+
     if (aCMenuItem == nil) {
         return 0L;
     }
-    
+
     // and add it to the parent item.
     [parentCMenu addJavaMenuItem: aCMenuItem];
-    
+
     // setLabel will be called after creation completes.
-    
+
     JNF_COCOA_EXIT(env);
     return ptr_to_jlong(aCMenuItem);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -362,9 +362,9 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
                 jLastPage = [nsLastPage integerValue] - 1;
             }
             isRangeSet = true;
-        } 
-        JNFCallVoidMethod(env, dstPrinterJob, jm_setPageRangeAttribute, 
-                          jFirstPage, jLastPage, isRangeSet); 
+        }
+        JNFCallVoidMethod(env, dstPrinterJob, jm_setPageRangeAttribute,
+                          jFirstPage, jLastPage, isRangeSet);
             // AWT_THREADING Safe (known object)
 
     }
@@ -419,7 +419,7 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
     [printingDictionary setObject:[NSNumber numberWithInteger:fromPage] forKey:NSPrintFirstPage];
     [printingDictionary setObject:[NSNumber numberWithInteger:toPage] forKey:NSPrintLastPage];
 
-    jobject page = JNFCallObjectMethod(env, srcPrinterJob, jm_getPageFormat); 
+    jobject page = JNFCallObjectMethod(env, srcPrinterJob, jm_getPageFormat);
     if (page != NULL) {
         javaPageFormatToNSPrintInfo(env, NULL, page, dst);
     }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -324,7 +324,7 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
     jint picHeight = height;
 
     CGRect screenRect = CGRectMake(picX / scale, picY / scale,
-    				picWidth / scale, picHeight / scale);
+                                picWidth / scale, picHeight / scale);
     CGImageRef screenPixelsImage = CGWindowListCreateImage(screenRect,
                                         kCGWindowListOptionOnScreenOnly,
                                         kCGNullWindowID, kCGWindowImageBestResolution);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobotKeyCode.m
@@ -168,7 +168,7 @@
 
 -(int) getOSXKeyCodeForJavaKey : (int) javaKey {
     id val = [javaToMacKeyMap objectForKey : [NSNumber numberWithInt : javaKey]];
-	
+
     if (nil != val) {
         return [val intValue];
     } else {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
@@ -242,10 +242,10 @@ void JavaCT_DrawTextUsingQSD(JNIEnv *env, const QuartzSDOps *qsdo, const AWTStri
 
     NSString *string = [NSString stringWithCharacters:chars length:length];
     /*
-       The calls below were used previously but for unknown reason did not 
-       render using the right font (see bug 7183516) when attribString is not 
-       initialized with font dictionary attributes.  It seems that "options" 
-       in CTTypesetterCreateWithAttributedStringAndOptions which contains the 
+       The calls below were used previously but for unknown reason did not
+       render using the right font (see bug 7183516) when attribString is not
+       initialized with font dictionary attributes.  It seems that "options"
+       in CTTypesetterCreateWithAttributedStringAndOptions which contains the
        font dictionary is ignored.
 
     NSAttributedString *attribString = [[NSAttributedString alloc] initWithString:string];
@@ -255,7 +255,7 @@ void JavaCT_DrawTextUsingQSD(JNIEnv *env, const QuartzSDOps *qsdo, const AWTStri
     NSAttributedString *attribString = [[NSAttributedString alloc]
         initWithString:string
         attributes:ctsDictionaryFor(nsFont, JRSFontStyleUsesFractionalMetrics(strike->fStyle))];
-    
+
     CTTypesetterRef typeSetterRef = CTTypesetterCreateWithAttributedString((CFAttributedStringRef) attribString);
 
     CFRange range = {0, length};
@@ -352,12 +352,12 @@ static inline void doDrawGlyphsPipe_checkForPerGlyphTransforms
     jdoubleArray g_gtiTransformsArray = JNFGetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_transforms); //(*env)->GetObjectField(env, gti, g_gtiTransforms);
     if (g_gtiTransformsArray == NULL) {
         return;
-    } 
+    }
     jdouble *g_gvTransformsAsDoubles = (*env)->GetPrimitiveArrayCritical(env, g_gtiTransformsArray, NULL);
     if (g_gvTransformsAsDoubles == NULL) {
         (*env)->DeleteLocalRef(env, g_gtiTransformsArray);
         return;
-    } 
+    }
 
     static JNF_MEMBER_CACHE(jm_StandardGlyphVector_GlyphTransformInfo_indices, jc_StandardGlyphVector_GlyphTransformInfo, "indices", "[I");
     jintArray g_gtiTXIndicesArray = JNFGetObjectField(env, gti, jm_StandardGlyphVector_GlyphTransformInfo_indices);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
@@ -422,16 +422,16 @@ Java_sun_lwawt_macosx_CWrapper_00024NSWindow_isZoomed
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
     __block jboolean isZoomed = JNI_FALSE;
-    
+
 JNF_COCOA_ENTER(env);
-    
+
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         isZoomed = [window isZoomed];
     }];
-    
+
 JNF_COCOA_EXIT(env);
-    
+
     return isZoomed;
 }
 
@@ -566,14 +566,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSView_setHidden
 (JNIEnv *env, jclass cls, jlong viewPtr, jboolean toHide)
-{    
+{
     JNF_COCOA_ENTER(env);
-    
+
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [view setHidden:(BOOL)toHide];
     }];
-    
+
     JNF_COCOA_EXIT(env);
 }
 
@@ -590,7 +590,7 @@ Java_sun_lwawt_macosx_CWrapper_00024NSView_setToolTip
 JNF_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
-    NSString* s = JNFJavaToNSString(env, msg); 
+    NSString* s = JNFJavaToNSString(env, msg);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [view setToolTip: s];
     }];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1207,12 +1207,12 @@ static NSObject *sAttributeNamesLOCK = nil;
             // handle case of AXMenuItem
             // need to ask menu what is selected
             NSArray *selectedChildrenOfMenu =
-            	[self accessibilitySelectedChildrenAttribute];
+                [self accessibilitySelectedChildrenAttribute];
             JavaComponentAccessibility *selectedMenuItem =
-            	[selectedChildrenOfMenu objectAtIndex:0];
+                [selectedChildrenOfMenu objectAtIndex:0];
             if (selectedMenuItem != nil) {
                 jobject itemValue =
-                	JNFCallStaticObjectMethod( env,
+                        JNFCallStaticObjectMethod( env,
                                                    sjm_getAccessibleName,
                                                    selectedMenuItem->fAccessible,
                                                    selectedMenuItem->fComponent ); // AWT_THREADING Safe (AWTRunLoop)
@@ -1223,7 +1223,7 @@ static NSObject *sAttributeNamesLOCK = nil;
                 (*env)->DeleteLocalRef(env, itemValue);
                 return itemString;
             } else {
-            	return nil;
+                return nil;
             }
         }
     }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaTextAccessibility.m
@@ -123,7 +123,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     jobject axText = JNFCallStaticObjectMethod(env, sjm_getAccessibleText, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (axText == NULL) return nil;
     (*env)->DeleteLocalRef(env, axText);
-    
+
     jobject axEditableText = JNFCallStaticObjectMethod(env, sjm_getAccessibleEditableText, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
     if (axEditableText == NULL) return nil;
 
@@ -133,7 +133,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
 
     (*env)->DeleteLocalRef(env, jrange);
     (*env)->DeleteLocalRef(env, axEditableText);
-    
+
     if (string == nil) string = @"";
     return string;
 }
@@ -305,7 +305,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     jdouble *values = (*env)->GetDoubleArrayElements(env, axBounds, 0);
     if (values == NULL) {
         // Note: Java will not be on the stack here so a java exception can't happen and no need to call ExceptionCheck.
-        NSLog(@"%s failed calling GetDoubleArrayElements", __FUNCTION__); 
+        NSLog(@"%s failed calling GetDoubleArrayElements", __FUNCTION__);
         return nil;
     };
     NSRect bounds;
@@ -427,7 +427,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     return javaIntArrayToNSRangeValue(env, axTextRange);
 }
 
-/* 
+/*
  * - (NSDictionary *)getActions:(JNIEnv *)env { ... }
  *
  * In the future, possibly add support: Editable text has AXShowMenu.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.m
@@ -34,17 +34,17 @@
 // returns 107 for Lion, 106 for SnowLeopard etc.
 int getOSXMajorVersion() {
     char *ver = JRSCopyOSVersion();
-    if (ver == NULL) { 
+    if (ver == NULL) {
         return 0;
     }
 
     int len = strlen(ver);
     int v = 0;
-    
-    // Third char must be a '.'    
+
+    // Third char must be a '.'
     if (len >= 3 && ver[2] == '.') {
         int i;
-        
+
         v = (ver[0] - '0') * 10 + (ver[1] - '0');
         for (i = 3; i < len && isdigit(ver[i]); ++i) {
             v = v * 10 + (ver[i] - '0');
@@ -52,7 +52,7 @@ int getOSXMajorVersion() {
     }
 
     free(ver);
-    
+
     return v;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -203,14 +203,14 @@ static JNF_CLASS_CACHE(sjc_PageFormat, "java/awt/print/PageFormat");
         // Actually print and get the PageFormatArea
         jobject pageFormatArea = JNFCallObjectMethod(env, fPrinterJob, jm_printAndGetPageFormatArea, fCurPainter, fCurPeekGraphics, fCurPageFormat, jPageNumber); // AWT_THREADING Safe (AWTRunLoopMode)
         if (pageFormatArea != NULL) {
-            NSPrintingOrientation currentOrientation = 
+            NSPrintingOrientation currentOrientation =
                     [[[NSPrintOperation currentOperation] printInfo] orientation];
             // set page orientation
-            switch (JNFCallIntMethod(env, fCurPageFormat, jm_getOrientation)) { 
+            switch (JNFCallIntMethod(env, fCurPageFormat, jm_getOrientation)) {
                 case java_awt_print_PageFormat_PORTRAIT:
                 default:
                     if (currentOrientation != NSPortraitOrientation) {
-                        [[[NSPrintOperation currentOperation] printInfo] 
+                        [[[NSPrintOperation currentOperation] printInfo]
                                             setOrientation:NSPortraitOrientation];
                     }
                     break;
@@ -218,7 +218,7 @@ static JNF_CLASS_CACHE(sjc_PageFormat, "java/awt/print/PageFormat");
                 case java_awt_print_PageFormat_LANDSCAPE:
                 case java_awt_print_PageFormat_REVERSE_LANDSCAPE:
                     if (currentOrientation != NSLandscapeOrientation) {
-                        [[[NSPrintOperation currentOperation] printInfo] 
+                        [[[NSPrintOperation currentOperation] printInfo]
                                             setOrientation:NSLandscapeOrientation];
                     }
                     break;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
@@ -275,7 +275,7 @@ PRINT("    contextQuartzLinearGradientPath");
 
     CGContextRef cgRef = qsdo->cgRef;
     StateGradientInfo *gradientInfo = qsdo->gradientInfo;
-   
+
     CGColorSpaceRef colorspace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
     size_t num_locations = gradientInfo->fractionsLength;
     CGFloat *locations = (CGFloat *) malloc(sizeof(CGFloat) * num_locations);
@@ -289,7 +289,7 @@ PRINT("    contextQuartzLinearGradientPath");
     }
     for (i = 0; i < component_size; i++) {
         components[i] = gradientInfo->colordata[i];
-    } 
+    }
     CGContextSaveGState(cgRef);
     gradient = CGGradientCreateWithColorComponents(colorspace, components, locations, num_locations);
     if (qsdo->isEvenOddFill) {
@@ -297,7 +297,7 @@ PRINT("    contextQuartzLinearGradientPath");
     } else {
         CGContextClip(cgRef);
     }
-    CGContextDrawLinearGradient(cgRef, gradient, gradientInfo->start, gradientInfo->end, kCGGradientDrawsAfterEndLocation);    
+    CGContextDrawLinearGradient(cgRef, gradient, gradientInfo->start, gradientInfo->end, kCGGradientDrawsAfterEndLocation);
 
     CGContextRestoreGState(cgRef);
     CGColorSpaceRelease(colorspace);
@@ -314,7 +314,7 @@ PRINT("    contextQuartzRadialGradientPath");
 
     CGContextRef cgRef = qsdo->cgRef;
     StateGradientInfo *gradientInfo = qsdo->gradientInfo;
-   
+
     CGColorSpaceRef colorspace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
     size_t num_locations = gradientInfo->fractionsLength;
     CGFloat *locations = (CGFloat *) malloc(sizeof(CGFloat) * num_locations);
@@ -330,7 +330,7 @@ PRINT("    contextQuartzRadialGradientPath");
     }
     for (i = 0; i < component_size; i++) {
         components[i] = gradientInfo->colordata[i];
-    } 
+    }
     CGContextSaveGState(cgRef);
     gradient = CGGradientCreateWithColorComponents(colorspace, components, locations, num_locations);
     if (qsdo->isEvenOddFill) {
@@ -338,8 +338,8 @@ PRINT("    contextQuartzRadialGradientPath");
     } else {
         CGContextClip(cgRef);
     }
-    CGContextDrawRadialGradient(cgRef, gradient, gradientInfo->start, 0, gradientInfo->end, endRadius, kCGGradientDrawsAfterEndLocation);    
-    
+    CGContextDrawRadialGradient(cgRef, gradient, gradientInfo->start, 0, gradientInfo->end, endRadius, kCGGradientDrawsAfterEndLocation);
+
     CGContextRestoreGState(cgRef);
     CGColorSpaceRelease(colorspace);
     CGGradientRelease(gradient);
@@ -351,7 +351,7 @@ PRINT("    contextQuartzRadialGradientPath");
 static inline void contextGradientPath(QuartzSDOps* qsdo)
 {
 PRINT("    ContextGradientPath")
- 
+
     CGContextRef cgRef = qsdo->cgRef;
     StateShadingInfo* shadingInfo = qsdo->shadingInfo;
 
@@ -925,7 +925,7 @@ void setupGradient(JNIEnv *env, QuartzSDOps* qsdo, jfloat* javaFloatGraphicsStat
     qsdo->gradientInfo->end.x    = javaFloatGraphicsStates[sun_java2d_OSXSurfaceData_kColorx2Index];
     qsdo->gradientInfo->end.y    = javaFloatGraphicsStates[sun_java2d_OSXSurfaceData_kColory2Index];
 
-    jobject colorArray  = ((*env)->GetObjectArrayElement(env, qsdo->javaGraphicsStatesObjects, sun_java2d_OSXSurfaceData_kColorArrayIndex)); 
+    jobject colorArray  = ((*env)->GetObjectArrayElement(env, qsdo->javaGraphicsStatesObjects, sun_java2d_OSXSurfaceData_kColorArrayIndex));
     if (colorArray != NULL)
     {
         jint length = (*env)->GetArrayLength(env, colorArray);
@@ -949,7 +949,7 @@ void setupGradient(JNIEnv *env, QuartzSDOps* qsdo, jfloat* javaFloatGraphicsStat
         }
         (*env)->ReleasePrimitiveArrayCritical(env, colorArray, jcolorData, 0);
     }
-    jobject fractionsArray  = ((*env)->GetObjectArrayElement(env, qsdo->javaGraphicsStatesObjects, sun_java2d_OSXSurfaceData_kFractionsArrayIndex)); 
+    jobject fractionsArray  = ((*env)->GetObjectArrayElement(env, qsdo->javaGraphicsStatesObjects, sun_java2d_OSXSurfaceData_kFractionsArrayIndex));
     if (fractionsArray != NULL)
     {
         jint length = (*env)->GetArrayLength(env, fractionsArray);
@@ -967,7 +967,7 @@ void setupGradient(JNIEnv *env, QuartzSDOps* qsdo, jfloat* javaFloatGraphicsStat
             }
             (*env)->ReleasePrimitiveArrayCritical(env, fractionsArray, jfractionsData, 0);
         }
-    }    
+    }
 }
 
 SDRenderType SetUpPaint(JNIEnv *env, QuartzSDOps *qsdo, SDRenderType renderType)

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.m
@@ -208,11 +208,11 @@ static inline UInt8* getReverseGammaLut() {
         if (pGammaEnv != NULL) {
             reverseGamma = atol(pGammaEnv);
         }
-        
+
         if (reverseGamma < 100 || reverseGamma > 250) {
             reverseGamma = 180;
         }
-        
+
         gamma = 100.0 / reverseGamma;
         for (i = 0; i < 256; i++) {
             double x = ((double)i) / 255.0;
@@ -226,7 +226,7 @@ static inline void
 CGGI_CopyARGBPixelToRGBPixel(const UInt32 p, UInt8 *dst)
 {
     UInt8* lut = getReverseGammaLut();
-    
+
     *(dst + 0) = lut[0xFF - (p >> 16 & 0xFF)];  // red
     *(dst + 1) = lut[0xFF - (p >>  8 & 0xFF)];  // green
     *(dst + 2) = lut[0xFF - (p & 0xFF)];        // blue
@@ -244,7 +244,7 @@ CGGI_CopyImageFromCanvasToRGBInfo(CGGI_GlyphCanvas *canvas, GlyphInfo *info)
     size_t height = info->height;
 
     size_t y;
-    
+
     // fill empty glyph image with black-on-white glyph
     for (y = 0; y < height; y++) {
         size_t destRow = y * destRowWidth * 3;
@@ -296,7 +296,7 @@ CGGI_CopyImageFromCanvasToAlphaInfo(CGGI_GlyphCanvas *canvas, GlyphInfo *info)
     size_t height = info->height;
 
     size_t y;
-    
+
     // fill empty glyph image with black-on-white glyph
     for (y = 0; y < height; y++) {
         size_t destRow = y * destRowWidth;
@@ -401,7 +401,7 @@ CGGI_InitCanvas(CGGI_GlyphCanvas *canvas,
 
     // set foreground color
     CGContextSetRGBFillColor(canvas->context, 0.0f, 0.0f, 0.0f, 1.0f);
-    
+
     CGContextSetFontSize(canvas->context, 1);
     CGContextSaveGState(canvas->context);
 
@@ -742,7 +742,7 @@ CGGI_FillImagesForGlyphs(jlong *glyphInfos, const AWTStrike *strike,
 
     NSString* theKey = (mode->glyphDescriptor == &rgb) ?
         threadLocalLCDCanvasKey : threadLocalAACanvasKey;
-    
+
     CGGI_GlyphCanvas *canvas = [threadDict objectForKey:theKey];
     if (canvas == nil) {
         canvas = [[CGGI_GlyphCanvas alloc] init];

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
@@ -73,9 +73,9 @@ AWT_ASSERT_APPKIT_THREAD;
 
 + (void)performOnMainThreadWaiting:(BOOL)wait block:(void (^)())block {
     if ([NSThread isMainThread] && wait == YES) {
-        block(); 
-    } else { 
-        [JNFRunLoop performOnMainThreadWaiting:wait withBlock:block]; 
+        block();
+    } else {
+        [JNFRunLoop performOnMainThreadWaiting:wait withBlock:block];
     }
 }
 

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk-font.cc
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk-font.cc
@@ -42,10 +42,10 @@
 
 static hb_bool_t
 hb_jdk_get_nominal_glyph (hb_font_t *font HB_UNUSED,
-		          void *font_data,
-		          hb_codepoint_t unicode,
-		          hb_codepoint_t *glyph,
-		          void *user_data HB_UNUSED)
+                          void *font_data,
+                          hb_codepoint_t unicode,
+                          hb_codepoint_t *glyph,
+                          void *user_data HB_UNUSED)
 {
 
     JDKFontInfo *jdkFontInfo = (JDKFontInfo*)font_data;
@@ -65,18 +65,18 @@ hb_jdk_get_nominal_glyph (hb_font_t *font HB_UNUSED,
 
 static hb_bool_t
 hb_jdk_get_variation_glyph (hb_font_t *font HB_UNUSED,
-		 void *font_data,
-		 hb_codepoint_t unicode,
-		 hb_codepoint_t variation_selector,
-		 hb_codepoint_t *glyph,
-		 void *user_data HB_UNUSED)
+                 void *font_data,
+                 hb_codepoint_t unicode,
+                 hb_codepoint_t variation_selector,
+                 hb_codepoint_t *glyph,
+                 void *user_data HB_UNUSED)
 {
 
     JDKFontInfo *jdkFontInfo = (JDKFontInfo*)font_data;
     JNIEnv* env = jdkFontInfo->env;
     jobject font2D = jdkFontInfo->font2D;
     *glyph = (hb_codepoint_t)env->CallIntMethod(
-              font2D, sunFontIDs.f2dCharToVariationGlyphMID, 
+              font2D, sunFontIDs.f2dCharToVariationGlyphMID,
               unicode, variation_selector);
     if (env->ExceptionOccurred())
     {
@@ -90,9 +90,9 @@ hb_jdk_get_variation_glyph (hb_font_t *font HB_UNUSED,
 
 static hb_position_t
 hb_jdk_get_glyph_h_advance (hb_font_t *font HB_UNUSED,
-			   void *font_data,
-			   hb_codepoint_t glyph,
-			   void *user_data HB_UNUSED)
+                           void *font_data,
+                           hb_codepoint_t glyph,
+                           void *user_data HB_UNUSED)
 {
 
     float fadv = 0.0f;
@@ -118,9 +118,9 @@ hb_jdk_get_glyph_h_advance (hb_font_t *font HB_UNUSED,
 
 static hb_position_t
 hb_jdk_get_glyph_v_advance (hb_font_t *font HB_UNUSED,
-			   void *font_data,
-			   hb_codepoint_t glyph,
-			   void *user_data HB_UNUSED)
+                           void *font_data,
+                           hb_codepoint_t glyph,
+                           void *user_data HB_UNUSED)
 {
 
     float fadv = 0.0f;
@@ -146,11 +146,11 @@ hb_jdk_get_glyph_v_advance (hb_font_t *font HB_UNUSED,
 
 static hb_bool_t
 hb_jdk_get_glyph_h_origin (hb_font_t *font HB_UNUSED,
-			  void *font_data HB_UNUSED,
-			  hb_codepoint_t glyph HB_UNUSED,
-			  hb_position_t *x HB_UNUSED,
-			  hb_position_t *y HB_UNUSED,
-			  void *user_data HB_UNUSED)
+                          void *font_data HB_UNUSED,
+                          hb_codepoint_t glyph HB_UNUSED,
+                          hb_position_t *x HB_UNUSED,
+                          hb_position_t *y HB_UNUSED,
+                          void *user_data HB_UNUSED)
 {
   /* We always work in the horizontal coordinates. */
   return true;
@@ -158,21 +158,21 @@ hb_jdk_get_glyph_h_origin (hb_font_t *font HB_UNUSED,
 
 static hb_bool_t
 hb_jdk_get_glyph_v_origin (hb_font_t *font HB_UNUSED,
-			  void *font_data,
-			  hb_codepoint_t glyph,
-			  hb_position_t *x,
-			  hb_position_t *y,
-			  void *user_data HB_UNUSED)
+                          void *font_data,
+                          hb_codepoint_t glyph,
+                          hb_position_t *x,
+                          hb_position_t *y,
+                          void *user_data HB_UNUSED)
 {
   return false;
 }
 
 static hb_position_t
 hb_jdk_get_glyph_h_kerning (hb_font_t *font,
-			   void *font_data,
-			   hb_codepoint_t lejdk_glyph,
-			   hb_codepoint_t right_glyph,
-			   void *user_data HB_UNUSED)
+                           void *font_data,
+                           hb_codepoint_t lejdk_glyph,
+                           hb_codepoint_t right_glyph,
+                           void *user_data HB_UNUSED)
 {
   /* Not implemented. This seems to be in the HB API
    * as a way to fall back to Freetype's kerning support
@@ -189,10 +189,10 @@ hb_jdk_get_glyph_h_kerning (hb_font_t *font,
 
 static hb_position_t
 hb_jdk_get_glyph_v_kerning (hb_font_t *font HB_UNUSED,
-			   void *font_data HB_UNUSED,
-			   hb_codepoint_t top_glyph HB_UNUSED,
-			   hb_codepoint_t bottom_glyph HB_UNUSED,
-			   void *user_data HB_UNUSED)
+                           void *font_data HB_UNUSED,
+                           hb_codepoint_t top_glyph HB_UNUSED,
+                           hb_codepoint_t bottom_glyph HB_UNUSED,
+                           void *user_data HB_UNUSED)
 {
   /* OpenType doesn't have vertical-kerning other than GPOS. */
   return 0;
@@ -200,10 +200,10 @@ hb_jdk_get_glyph_v_kerning (hb_font_t *font HB_UNUSED,
 
 static hb_bool_t
 hb_jdk_get_glyph_extents (hb_font_t *font HB_UNUSED,
-			 void *font_data,
-			 hb_codepoint_t glyph,
-			 hb_glyph_extents_t *extents,
-			 void *user_data HB_UNUSED)
+                         void *font_data,
+                         hb_codepoint_t glyph,
+                         hb_glyph_extents_t *extents,
+                         void *user_data HB_UNUSED)
 {
   /* TODO */
   return false;
@@ -211,12 +211,12 @@ hb_jdk_get_glyph_extents (hb_font_t *font HB_UNUSED,
 
 static hb_bool_t
 hb_jdk_get_glyph_contour_point (hb_font_t *font HB_UNUSED,
-			       void *font_data,
-			       hb_codepoint_t glyph,
-			       unsigned int point_index,
-			       hb_position_t *x,
-			       hb_position_t *y,
-			       void *user_data HB_UNUSED)
+                               void *font_data,
+                               hb_codepoint_t glyph,
+                               unsigned int point_index,
+                               hb_position_t *x,
+                               hb_position_t *y,
+                               void *user_data HB_UNUSED)
 {
     if ((glyph & 0xfffe) == 0xfffe) {
         *x = 0; *y = 0;
@@ -243,20 +243,20 @@ hb_jdk_get_glyph_contour_point (hb_font_t *font HB_UNUSED,
 
 static hb_bool_t
 hb_jdk_get_glyph_name (hb_font_t *font HB_UNUSED,
-		      void *font_data,
-		      hb_codepoint_t glyph,
-		      char *name, unsigned int size,
-		      void *user_data HB_UNUSED)
+                      void *font_data,
+                      hb_codepoint_t glyph,
+                      char *name, unsigned int size,
+                      void *user_data HB_UNUSED)
 {
   return false;
 }
 
 static hb_bool_t
 hb_jdk_get_glyph_from_name (hb_font_t *font HB_UNUSED,
-			   void *font_data,
-			   const char *name, int len,
-			   hb_codepoint_t *glyph,
-			   void *user_data HB_UNUSED)
+                           void *font_data,
+                           const char *name, int len,
+                           hb_codepoint_t *glyph,
+                           void *user_data HB_UNUSED)
 {
   return false;
 }

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -393,7 +393,7 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_readBytesFromProcess0(
   // Try to read each of the pages.
   for (i = 0; i < pageCount; i++) {
     result = vm_read(gTask, alignedAddress + i*vm_page_size, vm_page_size,
-		     &pages[i], &byteCount);
+                     &pages[i], &byteCount);
     mapped[i] = (result == KERN_SUCCESS);
     // assume all failures are unmapped pages
   }


### PR DESCRIPTION
Please review this patch for 15u-dev.
applied almost cleanly, I have to remove last chunk in src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
from original [patch](https://github.com/VladimirKempik/jdk/commit/c32923e06fc94c2a2ad8b9dd803aad1ed5386505) as it was already present in jdk15u-dev and wasn't needed.
Very safe, fomatting only change, needed for rest of JNF removal patches to apply more cleanly

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240487](https://bugs.openjdk.java.net/browse/JDK-8240487): Cleanup whitespace in .cc, .hh, .m, and .mm files ⚠️ Issue is not open.


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/8.diff">https://git.openjdk.java.net/jdk15u-dev/pull/8.diff</a>

</details>
