### PR TITLE
8259651: [macOS] Replace JNF_COCOA_ENTER/EXIT macros

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -27,7 +27,7 @@
 #import "java_awt_event_KeyEvent.h"
 #import "LWCToolkit.h"
 
-#import "jni_util.h"
+#import "JNIUtilities.h"
 
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <sys/time.h>
@@ -668,11 +668,11 @@ Java_sun_lwawt_macosx_NSEvent_nsToJavaModifiers
 {
     jint jmodifiers = 0;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jmodifiers = GetJavaMouseModifiers(modifierFlags);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return jmodifiers;
 }
@@ -688,7 +688,7 @@ Java_sun_lwawt_macosx_NSEvent_nsToJavaKeyInfo
 {
     BOOL postsTyped = NO;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jboolean copy = JNI_FALSE;
     jint *data = (*env)->GetIntArrayElements(env, inData, &copy);
@@ -716,7 +716,7 @@ JNF_COCOA_ENTER(env);
 
     (*env)->ReleaseIntArrayElements(env, inData, data, 0);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return postsTyped;
 }
@@ -730,7 +730,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_NSEvent_nsKeyModifiersToJavaKeyInfo
 (JNIEnv *env, jclass cls, jintArray inData, jintArray outData)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jboolean copy = JNI_FALSE;
     jint *data = (*env)->GetIntArrayElements(env, inData, &copy);
@@ -757,7 +757,7 @@ JNF_COCOA_ENTER(env);
 
     (*env)->ReleaseIntArrayElements(env, inData, data, 0);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -771,11 +771,11 @@ Java_sun_lwawt_macosx_NSEvent_nsToJavaChar
 {
     jchar javaChar = 0;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     javaChar = NsCharToJavaChar(nsChar, modifierFlags, spaceKeyTyped);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return javaChar;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTSurfaceLayers.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTSurfaceLayers.m
@@ -26,6 +26,7 @@
 #import "AWTSurfaceLayers.h"
 #import "ThreadUtilities.h"
 #import "LWCToolkit.h"
+#import "JNIUtilities.h"
 
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <QuartzCore/CATransaction.h>
@@ -101,7 +102,7 @@ Java_sun_lwawt_macosx_CPlatformComponent_nativeCreateComponent
 {
   __block AWTSurfaceLayers *surfaceLayers = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
 
@@ -109,7 +110,7 @@ JNF_COCOA_ENTER(env);
         surfaceLayers = [[AWTSurfaceLayers alloc] initWithWindowLayer: windowLayer];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
   return ptr_to_jlong(surfaceLayers);
 }
@@ -122,7 +123,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformComponent_nativeSetBounds
 (JNIEnv *env, jclass clazz, jlong surfaceLayersPtr, jint x, jint y, jint width, jint height)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
   AWTSurfaceLayers *surfaceLayers = OBJC(surfaceLayersPtr);
 
@@ -132,5 +133,5 @@ JNF_COCOA_ENTER(env);
       [surfaceLayers setBounds: rect];
   }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1405,7 +1405,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeCreateView
 {
     __block AWTView *newView = nil;
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSRect rect = NSMakeRect(originX, originY, width, height);
     jobject cPlatformView = (*env)->NewWeakGlobalRef(env, obj);
@@ -1418,7 +1418,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeCreateView
                                     windowLayer:windowLayer];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(newView);
 }
@@ -1433,7 +1433,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CPlatformView_nativeSetAutoResizable
 (JNIEnv *env, jclass cls, jlong viewPtr, jboolean toResize)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
 
@@ -1450,7 +1450,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeSetAutoResizable
         }
 
     }];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1465,7 +1465,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeGetNSViewDisplayID
 {
     __block jint ret; //CGDirectDisplayID
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
@@ -1473,7 +1473,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeGetNSViewDisplayID
         ret = (jint)[[AWTWindow getNSWindowDisplayID_AppKitThread: window] intValue];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return ret;
 }
@@ -1490,7 +1490,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeGetLocationOnScreen
 {
     jobject jRect = NULL;
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     __block NSRect rect = NSZeroRect;
 
@@ -1506,7 +1506,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeGetLocationOnScreen
     }];
     jRect = NSToJavaRect(env, rect);
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return jRect;
 }
@@ -1522,7 +1522,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPlatformView_nativeIsViewUnder
 {
     __block jboolean underMouse = JNI_FALSE;
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSView *nsView = OBJC(viewPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
@@ -1531,7 +1531,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPlatformView_nativeIsViewUnder
         underMouse = [nsView hitTest:ptViewCoords] != nil;
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return underMouse;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1101,7 +1101,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeCreateNSWind
 {
     __block AWTWindow *window = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     JNFWeakJObjectWrapper *platformWindow = [JNFWeakJObjectWrapper wrapperWithJObject:obj withEnv:env];
     NSView *contentView = OBJC(contentViewPtr);
@@ -1119,7 +1119,7 @@ JNF_COCOA_ENTER(env);
         if (window) [window.nsWindow retain];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(window ? window.nsWindow : nil);
 }
@@ -1132,7 +1132,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowStyleBits
 (JNIEnv *env, jclass clazz, jlong windowPtr, jint mask, jint bits)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
 
@@ -1180,7 +1180,7 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1191,7 +1191,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowMenuBar
 (JNIEnv *env, jclass clazz, jlong windowPtr, jlong menuBarPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     CMenuBar *menuBar = OBJC(menuBarPtr);
@@ -1215,7 +1215,7 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1228,7 +1228,7 @@ JNIEXPORT jobject JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeGetNSWindo
 {
     jobject ret = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     __block NSRect contentRect = NSZeroRect;
@@ -1249,7 +1249,7 @@ JNF_COCOA_ENTER(env);
     DECLARE_METHOD_RETURN(jc_Insets_ctor, jc_Insets, "<init>", "(IIII)V", NULL);
     ret = (*env)->NewObject(env, jc_Insets, jc_Insets_ctor, top, left, bottom, right);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return ret;
 }
 
@@ -1261,7 +1261,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowBounds
 (JNIEnv *env, jclass clazz, jlong windowPtr, jdouble originX, jdouble originY, jdouble width, jdouble height)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSRect jrect = NSMakeRect(originX, originY, width, height);
 
@@ -1295,7 +1295,7 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1307,7 +1307,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowSt
 (JNIEnv *env, jclass clazz, jlong windowPtr, jdouble originX, jdouble originY,
      jdouble width, jdouble height)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSRect jrect = NSMakeRect(originX, originY, width, height);
 
@@ -1319,7 +1319,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowSt
         window.standardFrame = rect;
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1330,7 +1330,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowSt
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowLocationByPlatform
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1344,7 +1344,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowLo
         lastTopLeftPoint = [nsWindow cascadeTopLeftFromPoint:lastTopLeftPoint];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1355,7 +1355,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowLo
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowMinMax
 (JNIEnv *env, jclass clazz, jlong windowPtr, jdouble minW, jdouble minH, jdouble maxW, jdouble maxH)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     if (minW < 1) minW = 1;
     if (minH < 1) minH = 1;
@@ -1378,7 +1378,7 @@ JNF_COCOA_ENTER(env);
         [window updateMinMaxSize:IS(window.styleBits, RESIZABLE)];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1389,7 +1389,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativePushNSWindowToBack
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1406,7 +1406,7 @@ JNF_COCOA_ENTER(env);
         [(AWTWindow*)[nsWindow delegate] orderChildWindows:NO];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1417,7 +1417,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativePushNSWindowToFront
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1429,7 +1429,7 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1440,14 +1440,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowTitle
 (JNIEnv *env, jclass clazz, jlong windowPtr, jstring jtitle)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [nsWindow performSelectorOnMainThread:@selector(setTitle:)
                               withObject:JNFJavaToNSString(env, jtitle)
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1458,14 +1458,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeRevalidateNSWindowShadow
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [nsWindow invalidateShadow];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1478,14 +1478,14 @@ JNIEXPORT jint JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeScreenOn_1App
 {
     jint ret = 0;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 AWT_ASSERT_APPKIT_THREAD;
 
     NSWindow *nsWindow = OBJC(windowPtr);
     NSDictionary *props = [[nsWindow screen] deviceDescription];
     ret = [[props objectForKey:@"NSScreenNumber"] intValue];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ret;
 }
@@ -1498,7 +1498,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowMinimizedIcon
 (JNIEnv *env, jclass clazz, jlong windowPtr, jlong nsImagePtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     NSImage *image = OBJC(nsImagePtr);
@@ -1506,7 +1506,7 @@ JNF_COCOA_ENTER(env);
         [nsWindow setMiniwindowImage:image];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1517,7 +1517,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowRepresentedFilename
 (JNIEnv *env, jclass clazz, jlong windowPtr, jstring filename)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     NSURL *url = (filename == NULL) ? nil : [NSURL fileURLWithPath:JNFNormalizedNSStringForPath(env, filename)];
@@ -1525,7 +1525,7 @@ JNF_COCOA_ENTER(env);
         [nsWindow setRepresentedURL:url];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1539,7 +1539,7 @@ JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeGetTopmostPlatformWindowUnde
 {
     __block jobject topmostWindowUnderMouse = nil;
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^{
         AWTWindow *awtWindow = [AWTWindow getTopmostWindowUnderMouse];
@@ -1548,7 +1548,7 @@ JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeGetTopmostPlatformWindowUnde
         }
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return topmostWindowUnderMouse;
 }
@@ -1561,13 +1561,13 @@ JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeGetTopmostPlatformWindowUnde
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSynthesizeMouseEnteredExitedEvents__
 (JNIEnv *env, jclass clazz)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [AWTWindow synthesizeMouseEnteredExitedEventsForAllWindows];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1578,7 +1578,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSynthesizeMou
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSynthesizeMouseEnteredExitedEvents__JI
 (JNIEnv *env, jclass clazz, jlong windowPtr, jint eventType)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     if (eventType == NSMouseEntered || eventType == NSMouseExited) {
         NSWindow *nsWindow = OBJC(windowPtr);
@@ -1587,10 +1587,10 @@ JNF_COCOA_ENTER(env);
             [AWTWindow synthesizeMouseEnteredExitedEvents:nsWindow withType:eventType];
         }];
     } else {
-        [JNFException raise:env as:kIllegalArgumentException reason:"unknown event type"];
+        JNU_ThrowIllegalArgumentException(env, "unknown event type");
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1601,7 +1601,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow__1toggleFullScreenMode
 (JNIEnv *env, jobject peer, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     SEL toggleFullScreenSelector = @selector(toggleFullScreen:);
@@ -1611,13 +1611,13 @@ JNF_COCOA_ENTER(env);
         [nsWindow performSelector:toggleFullScreenSelector withObject:nil];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetEnabled
 (JNIEnv *env, jclass clazz, jlong windowPtr, jboolean isEnabled)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1626,13 +1626,13 @@ JNF_COCOA_ENTER(env);
         [window setEnabled: isEnabled];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeDispose
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1651,13 +1651,13 @@ JNF_COCOA_ENTER(env);
         [window release];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeEnterFullScreenMode
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1677,19 +1677,17 @@ JNF_COCOA_ENTER(env);
             NSRect screenRect = [[nsWindow screen] frame];
             [nsWindow setFrame:screenRect display:YES];
         } else {
-            [JNFException raise:[ThreadUtilities getJNIEnv]
-                             as:kRuntimeException
-                         reason:"Failed to enter full screen."];
+            [NSException raise:@"Java Exception" reason:@"Failed to enter full screen." userInfo:nil];
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeExitFullScreenMode
 (JNIEnv *env, jclass clazz, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -1704,12 +1702,10 @@ JNF_COCOA_ENTER(env);
 
             // GraphicsDevice takes care of restoring pre full screen bounds
         } else {
-            [JNFException raise:[ThreadUtilities getJNIEnv]
-                             as:kRuntimeException
-                         reason:"Failed to exit full screen."];
+            [NSException raise:@"Java Exception" reason:@"Failed to exit full screen." userInfo:nil];
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -570,12 +570,12 @@ AWT_ASSERT_APPKIT_THREAD;
 JNIEXPORT void JNICALL Java_com_apple_eawt_Application_nativeInitializeApplicationDelegate
 (JNIEnv *env, jclass clz)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Force initialization to happen on AppKit thread!
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [ApplicationDelegate sharedDelegate];
     }];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -586,13 +586,13 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppEventHandler_nativeOpenCocoaAboutWindow
 (JNIEnv *env, jclass clz)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [NSApp orderFrontStandardAboutPanel:nil];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -603,13 +603,13 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppEventHandler_nativeReplyToAppShouldTerminate
 (JNIEnv *env, jclass clz, jboolean doTerminate)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [NSApp replyToApplicationShouldTerminate:doTerminate];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -620,12 +620,12 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppEventHandler_nativeRegisterForNotification
 (JNIEnv *env, jclass clz, jint notificationType)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(_registerForNotification:)
                                       on:[ApplicationDelegate class]
                               withObject:[NSNumber numberWithInt:notificationType]
                            waitUntilDone:NO]; // AWT_THREADING Safe (non-blocking)
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -636,14 +636,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppDockIconHandler_nativeSetDockMenu
 (JNIEnv *env, jclass clz, jlong nsMenuPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSMenu *menu = (NSMenu *)jlong_to_ptr(nsMenuPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         [ApplicationDelegate sharedDelegate].fDockMenu = menu;
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -654,7 +654,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppDockIconHandler_nativeSetDockIconImage
 (JNIEnv *env, jclass clz, jlong nsImagePtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSImage *_image = (NSImage *)jlong_to_ptr(nsImagePtr);
     [ThreadUtilities performOnMainThread:@selector(_setDockIconImage:)
@@ -662,7 +662,7 @@ JNF_COCOA_ENTER(env);
                               withObject:_image
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -673,14 +673,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppDockIconHandler_nativeSetDockIconProgress
   (JNIEnv *env, jclass clz, jint value)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
      [ThreadUtilities performOnMainThread:@selector(_setDockIconProgress:)
                                        on:[ApplicationDelegate class]
                                withObject:[NSNumber numberWithInt:value]
                             waitUntilDone:NO];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -693,13 +693,13 @@ JNIEXPORT jlong JNICALL Java_com_apple_eawt__1AppDockIconHandler_nativeGetDockIc
 {
     __block NSImage *image = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         image = [[ApplicationDelegate _dockIconImage] retain];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(image);
 }
@@ -712,7 +712,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppDockIconHandler_nativeSetDockIconBadge
 (JNIEnv *env, jclass clz, jstring badge)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *badgeString = JNFJavaToNSString(env, badge);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -721,7 +721,7 @@ JNF_COCOA_ENTER(env);
         [dockTile display];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -732,7 +732,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMiscHandlers_nativeRequestActivation
 (JNIEnv *env, jclass clz, jboolean allWindows)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         NSApplicationActivationOptions options = allWindows ? NSApplicationActivateAllWindows : 0;
@@ -740,7 +740,7 @@ JNF_COCOA_ENTER(env);
         [[NSRunningApplication currentApplication] activateWithOptions:options];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -751,13 +751,13 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMiscHandlers_nativeRequestUserAttention
 (JNIEnv *env, jclass clz, jboolean critical)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [NSApp requestUserAttention:critical ? NSCriticalRequest : NSInformationalRequest];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -768,14 +768,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMiscHandlers_nativeOpenHelpViewer
 (JNIEnv *env, jclass clz)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThread:@selector(showHelp:)
                                       on:NSApp
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -786,11 +786,11 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMiscHandlers_nativeEnableSuddenTermination
 (JNIEnv *env, jclass clz)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [[NSProcessInfo processInfo] enableSuddenTermination]; // Foundation thread-safe
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -801,11 +801,11 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMiscHandlers_nativeDisableSuddenTermination
 (JNIEnv *env, jclass clz)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [[NSProcessInfo processInfo] disableSuddenTermination]; // Foundation thread-safe
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -816,7 +816,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMenuBarHandler_nativeSetMenuState
 (JNIEnv *env, jclass clz, jint menuID, jboolean visible, jboolean enabled)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         ApplicationDelegate *delegate = [ApplicationDelegate sharedDelegate];
@@ -830,7 +830,7 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -841,14 +841,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMenuBarHandler_nativeSetDefaultMenuBar
 (JNIEnv *env, jclass clz, jlong cMenuBarPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CMenuBar *menu = (CMenuBar *)jlong_to_ptr(cMenuBarPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [ApplicationDelegate sharedDelegate].fDefaultMenuBar = menu;
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -859,7 +859,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eawt__1AppMenuBarHandler_nativeActivateDefaultMenuBar
 (JNIEnv *env, jclass clz, jlong cMenuBarPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CMenuBar *menu = (CMenuBar *)jlong_to_ptr(cMenuBarPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -868,5 +868,5 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -131,7 +131,7 @@
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CClipboard_declareTypes
 (JNIEnv *env, jobject inObject, jlongArray inTypes, jobject inJavaClip)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jint i;
     jint nElements = (*env)->GetArrayLength(env, inTypes);
@@ -146,7 +146,7 @@ JNF_COCOA_ENTER(env);
 
     (*env)->ReleasePrimitiveArrayCritical(env, inTypes, elements, JNI_ABORT);
     [[CClipboard sharedClipboard] declareTypes:formatArray withOwner:inJavaClip jniEnv:env];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -161,7 +161,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CClipboard_setData
         return;
     }
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     jint nBytes = (*env)->GetArrayLength(env, inBytes);
     jbyte *rawBytes = (*env)->GetPrimitiveArrayCritical(env, inBytes, NULL);
     CHECK_NULL(rawBytes);
@@ -171,7 +171,7 @@ JNF_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
         [[NSPasteboard generalPasteboard] setData:bytesAsData forType:format];
     }];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -183,7 +183,7 @@ JNIEXPORT jlongArray JNICALL Java_sun_lwawt_macosx_CClipboard_getClipboardFormat
 (JNIEnv *env, jobject inObject)
 {
     jlongArray returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     __block NSArray* dataTypes;
     [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
@@ -228,7 +228,7 @@ JNF_COCOA_ENTER(env);
     }
 
     (*env)->ReleaseLongArrayElements(env, returnValue, saveFormats, JNI_COMMIT);
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -244,7 +244,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_lwawt_macosx_CClipboard_getClipboardData
 
     // Note that this routine makes no attempt to interpret the data, since we're returning
     // a byte array back to Java.  CDataTransferer will do that if necessary.
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *formatAsString = formatForIndex(format);
     __block NSData* clipData;
@@ -253,7 +253,7 @@ JNF_COCOA_ENTER(env);
     }];
 
     if (clipData == NULL) {
-        [JNFException raise:env as:"java/io/IOException" reason:"Font transform has NaN position"];
+        JNU_ThrowIOException(env, "Font transform has NaN position");
         return NULL;
     } else {
         [clipData autorelease];
@@ -270,7 +270,7 @@ JNF_COCOA_ENTER(env);
         (*env)->SetByteArrayRegion(env, returnValue, 0, dataSize, (jbyte *)dataBuffer);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -283,11 +283,11 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CClipboard_checkPasteboardWitho
 (JNIEnv *env, jobject inObject)
 {
     __block BOOL ret = NO;
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         ret = [[CClipboard sharedClipboard] checkPasteboardWithoutNotification:nil];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
     return ret;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CCursorManager.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CCursorManager.m
@@ -73,31 +73,33 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CCursorManager_nativeSetBuiltInCursor
 (JNIEnv *env, jclass class, jint type, jstring name)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *cursorName = JNFJavaToNSString(env, name);
     SEL cursorSelector = (type == sun_lwawt_macosx_CCursorManager_NAMED_CURSOR) ? lookupCursorSelectorForName(cursorName) : lookupCursorSelectorForType(type);
     if (cursorSelector == nil) {
         NSString *reason = [NSString stringWithFormat:@"unimplemented built-in cursor type: %d / %@", type, cursorName];
-        [JNFException raise:env as:kIllegalArgumentException reason:[reason UTF8String]];
+        JNU_ThrowIllegalArgumentException(env, [reason UTF8String]);
+        return;
     }
 
     if (![[NSCursor class] respondsToSelector:cursorSelector]) {
-        [JNFException raise:env as:kNoSuchMethodException reason:"missing NSCursor selector"];
+        JNU_ThrowByName(env, "java/lang/NoSuchMethodException", "missing NSCursor selector");
+        return;
     }
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         setCursorOnAppKitThread([[NSCursor class] performSelector:cursorSelector]);
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CCursorManager_nativeSetCustomCursor
 (JNIEnv *env, jclass class, jlong imgPtr, jdouble x, jdouble y)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     NSImage *image = (NSImage *)jlong_to_ptr(imgPtr);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
@@ -107,7 +109,7 @@ JNF_COCOA_ENTER(env);
         [cursor release];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT jobject JNICALL
@@ -116,7 +118,7 @@ Java_sun_lwawt_macosx_CCursorManager_nativeGetCursorPosition
 {
     jobject jpt = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CGEventRef event = CGEventCreate(NULL);
     CGPoint globalPos = CGEventGetLocation(event);
@@ -124,7 +126,7 @@ JNF_COCOA_ENTER(env);
 
     jpt = NSToJavaPoint(env, globalPos);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return jpt;
 }
@@ -134,7 +136,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CCursorManager_nativeSetAllowsCursorSetInBackground
 (JNIEnv *env, jclass class, jboolean allows)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     SEL allowsSetInBackground_SEL = @selector(javaSetAllowsCursorSetInBackground:);
     if ([[NSCursor class] respondsToSelector:allowsSetInBackground_SEL]) {
@@ -150,6 +152,6 @@ JNF_COCOA_ENTER(env);
         }];
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDataTransferer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDataTransferer.m
@@ -26,7 +26,7 @@
 #import "CDataTransferer.h"
 #include "sun_lwawt_macosx_CDataTransferer.h"
 
-#import "jni_util.h"
+#import "JNIUtilities.h"
 
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
@@ -109,9 +109,9 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CDataTransferer_registerFormatWith
 (JNIEnv *env, jobject jthis, jstring newformat)
 {
     jlong returnValue = -1;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     returnValue = registerFormatWithPasteboard(JNFJavaToNSString(env, newformat));
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -124,9 +124,9 @@ JNIEXPORT jstring JNICALL Java_sun_lwawt_macosx_CDataTransferer_formatForIndex
   (JNIEnv *env, jobject jthis, jlong index)
 {
     jstring returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     returnValue = JNFNSToJavaString(env, formatForIndex(index));
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -200,7 +200,7 @@ Java_sun_lwawt_macosx_CDataTransferer_nativeDragQueryFile
 
     jobjectArray jreturnArray = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Get byte array elements:
     jboolean isCopy;
     jbyte* jbytes = (*env)->GetByteArrayElements(env, jbytearray, &isCopy);
@@ -250,6 +250,6 @@ JNF_COCOA_ENTER(env);
 
     // We're done with the jbytes (backing the plist/plistArray):
     (*env)->ReleaseByteArrayElements(env, jbytearray, jbytes, JNI_ABORT);
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return jreturnArray;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
@@ -24,6 +24,7 @@
  */
 
 
+#import "JNIUtilities.h"
 #import <CoreFoundation/CoreFoundation.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
@@ -37,7 +38,7 @@ JNIEXPORT jint JNICALL Java_sun_lwawt_macosx_CDesktopPeer__1lsOpenURI
 (JNIEnv *env, jclass clz, jstring uri)
 {
     OSStatus status = noErr;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     // I would love to use NSWorkspace here, but it's not thread safe. Why? I don't know.
     // So we use LaunchServices directly.
@@ -49,7 +50,7 @@ JNF_COCOA_ENTER(env);
     LSApplicationParameters params = {0, flags, NULL, NULL, NULL, NULL, NULL};
     status = LSOpenURLsWithRole((CFArrayRef)[NSArray arrayWithObject:url], kLSRolesAll, NULL, &params, NULL, 0);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return status;
 }
 
@@ -62,7 +63,7 @@ JNIEXPORT jint JNICALL Java_sun_lwawt_macosx_CDesktopPeer__1lsOpenFile
 (JNIEnv *env, jclass clz, jstring jpath, jboolean print)
 {
     OSStatus status = noErr;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     // I would love to use NSWorkspace here, but it's not thread safe. Why? I don't know.
     // So we use LaunchServices directly.
@@ -81,7 +82,7 @@ JNF_COCOA_ENTER(env);
     status = LSOpenURLsWithRole((CFArrayRef)[NSArray arrayWithObject:url], kLSRolesAll, NULL, &params, NULL, 0);
     [url release];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return status;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
@@ -645,7 +645,7 @@ static BOOL                sNeedsEnter;
     //DLog4(@"[CDragSource draggedImage moved]: (%d, %d) %@\n", (int) screenPoint.x, (int) screenPoint.y, self);
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [AWTToolkit eventCountPlusPlus];
     // There are two things we would be interested in:
     // a) mouse pointer has moved
@@ -695,7 +695,7 @@ JNF_COCOA_ENTER(env);
         (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMouseMovedMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
         CHECK_EXCEPTION();
     }
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 - (BOOL)ignoreModifierKeysWhileDragging {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSourceContextPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSourceContextPeer.m
@@ -25,6 +25,7 @@
 
 #import "sun_lwawt_macosx_CDragSourceContextPeer.h"
 
+#import "JNIUtilities.h"
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "CDragSource.h"
@@ -46,7 +47,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CDragSourceContextPeer_createNativ
     id controlObj = (id) jlong_to_ptr(jnativepeer);
     __block CDragSource* dragSource = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     // Global references are disposed when the DragSource is removed
     jobject gComponent = JNFNewGlobalRef(env, jcomponent);
@@ -74,7 +75,7 @@ JNF_COCOA_ENTER(env);
                                        formats:gFormats
                                      formatMap:gFormatMap];
     }];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(dragSource);
 }
@@ -91,9 +92,9 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CDragSourceContextPeer_doDragging
 
     CDragSource* dragSource = (CDragSource*) jlong_to_ptr(nativeDragSourceVal);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [dragSource drag];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -106,7 +107,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CDragSourceContextPeer_releaseNativ
 {
       CDragSource* dragSource = (CDragSource*) jlong_to_ptr(nativeDragSourceVal);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [dragSource removeFromView:env];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
@@ -731,10 +731,10 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CDropTarget_createNativeDropTarget
 {
     CDropTarget* dropTarget = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     id controlObj = (id) jlong_to_ptr(jnativepeer);
     dropTarget = [[CDropTarget alloc] init:jdroptarget component:jcomponent control:controlObj];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(dropTarget);
 }
@@ -749,7 +749,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CDropTarget_releaseNativeDropTarget
 {
     id dropTarget = (id)jlong_to_ptr(nativeDropTargetVal);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [dropTarget removeFromView:env];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTargetContextPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTargetContextPeer.m
@@ -76,7 +76,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CDropTargetContextPeer_startTransf
     // works off a data copy and doesn't have to go to the native event thread to get the data.
     // We can have endTransfer just call startTransfer.
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Get the drop target native object:
     CDropTarget* dropTarget = GetCDropTarget(jdroptarget);
     if (dropTarget == nil) {
@@ -113,7 +113,7 @@ JNF_COCOA_ENTER(env);
 
     // if no error return dropTarget's draggingSequence
     result = [dropTarget getDraggingSequenceNumber];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return result;
 }
@@ -144,7 +144,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CDropTargetContextPeer_dropDone
   (JNIEnv *env, jobject jthis, jlong jdroptarget, jlong jdroptransfer, jboolean jislocal, jboolean jsuccess, jint jdropaction)
 {
     // Get the drop target native object:
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     CDropTarget* dropTarget = GetCDropTarget(jdroptarget);
     if (dropTarget == nil) {
         DLog2(@"[CDropTargetContextPeer dropDone]: GetCDropTarget failed for %d.\n", (NSInteger) jdroptarget);
@@ -153,7 +153,7 @@ JNF_COCOA_ENTER(env);
 
     // Notify drop target Java is all done with this dragging sequence:
     [dropTarget javaDraggingEnded:(jlong)jdroptransfer success:jsuccess action:jdropaction];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CFRetainedResource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CFRetainedResource.m
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#import "JNIUtilities.h"
+
 #import <Cocoa/Cocoa.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
@@ -53,11 +55,11 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CFRetainedResource_nativeCFRelease
         }
     } else {
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
         CFRelease(jlong_to_ptr(ptr));
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CFileDialog.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CFileDialog.m
@@ -198,7 +198,7 @@ Java_sun_lwawt_macosx_CFileDialog_nativeRunFileDialog
 {
     jobjectArray returnValue = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     NSString *dialogTitle = JNFJavaToNSString(env, title);
     if ([dialogTitle length] == 0) {
         dialogTitle = @" ";
@@ -235,6 +235,6 @@ JNF_COCOA_ENTER(env);
     }
 
     [dialogDelegate release];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -151,7 +151,7 @@ static CGDisplayModeRef getBestModeForParameters(CFArrayRef allModes, int w, int
 static jobject createJavaDisplayMode(CGDisplayModeRef mode, JNIEnv *env) {
     jobject ret = NULL;
     jint h = DEFAULT_DEVICE_HEIGHT, w = DEFAULT_DEVICE_WIDTH, bpp = 0, refrate = 0;
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     if (mode) {
         CFStringRef currentBPP = CGDisplayModeCopyPixelEncoding(mode);
         bpp = getBPPFromModeString(currentBPP);
@@ -164,7 +164,7 @@ static jobject createJavaDisplayMode(CGDisplayModeRef mode, JNIEnv *env) {
     DECLARE_METHOD_RETURN(jc_DisplayMode_ctor, jc_DisplayMode, "<init>", "(IIII)V", ret);
     ret = (*env)->NewObject(env, jc_DisplayMode, jc_DisplayMode_ctor, w, h, bpp, refrate);
     CHECK_EXCEPTION();
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
     return ret;
 }
 
@@ -234,7 +234,7 @@ Java_sun_awt_CGraphicsDevice_nativeGetScreenInsets
     jobject ret = NULL;
     __block NSRect frame = NSZeroRect;
     __block NSRect visibleFrame = NSZeroRect;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         NSArray *screens = [NSScreen screens];
@@ -258,7 +258,7 @@ JNF_COCOA_ENTER(env);
     DECLARE_METHOD_RETURN(jc_Insets_ctor, jc_Insets, "<init>", "(IIII)V", ret);
     ret = (*env)->NewObject(env, jc_Insets, jc_Insets_ctor, top, left, bottom, right);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ret;
 }
@@ -272,7 +272,7 @@ JNIEXPORT void JNICALL
 Java_sun_awt_CGraphicsDevice_nativeSetDisplayMode
 (JNIEnv *env, jclass class, jint displayID, jint w, jint h, jint bpp, jint refrate)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     CFArrayRef allModes = getAllValidDisplayModes(displayID);
     CGDisplayModeRef closestMatch = getBestModeForParameters(allModes, (int)w, (int)h, (int)bpp, (int)refrate);
 
@@ -289,14 +289,14 @@ Java_sun_awt_CGraphicsDevice_nativeSetDisplayMode
             CGDisplayModeRelease(closestMatch);
         }];
     } else {
-        [JNFException raise:env as:kIllegalArgumentException reason:"Invalid display mode"];
+        JNU_ThrowIllegalArgumentException(env, "Invalid display mode");
     }
 
     if (retCode != kCGErrorSuccess){
-        [JNFException raise:env as:kIllegalArgumentException reason:"Unable to set display mode!"];
+        JNU_ThrowIllegalArgumentException(env, "Unable to set display mode!");
     }
     CFRelease(allModes);
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 /*
  * Class:     sun_awt_CGraphicsDevice
@@ -325,7 +325,7 @@ Java_sun_awt_CGraphicsDevice_nativeGetDisplayModes
 (JNIEnv *env, jclass class, jint displayID)
 {
     jobjectArray jreturnArray = NULL;
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     CFArrayRef allModes = getAllValidDisplayModes(displayID);
 
     CFIndex numModes = allModes ? CFArrayGetCount(allModes): 0;
@@ -354,7 +354,7 @@ Java_sun_awt_CGraphicsDevice_nativeGetDisplayModes
     if (allModes) {
         CFRelease(allModes);
     }
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return jreturnArray;
 }
@@ -370,7 +370,7 @@ Java_sun_awt_CGraphicsDevice_nativeGetScaleFactor
 {
     __block jdouble ret = 1.0f;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         NSArray *screens = [NSScreen screens];
@@ -386,6 +386,6 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return ret;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
@@ -43,23 +43,19 @@ Java_sun_awt_CGraphicsEnvironment_getDisplayIDs
 {
     jintArray ret = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     /* Get the count */
     CGDisplayCount displayCount;
     if (CGGetOnlineDisplayList(MAX_DISPLAYS, NULL, &displayCount) != kCGErrorSuccess) {
-        [JNFException raise:env
-                         as:kInternalError
-                     reason:"CGGetOnlineDisplayList() failed to get display count"];
+        JNU_ThrowInternalError(env, "CGGetOnlineDisplayList() failed to get display count");
         return NULL;
     }
 
     /* Allocate an array and get the size list of display Ids */
     CGDirectDisplayID displays[MAX_DISPLAYS];
     if (CGGetOnlineDisplayList(displayCount, displays, &displayCount) != kCGErrorSuccess) {
-        [JNFException raise:env
-                         as:kInternalError
-                     reason:"CGGetOnlineDisplayList() failed to get display list"];
+        JNU_ThrowInternalError(env, "CGGetOnlineDisplayList() failed to get display list");
         return NULL;
     }
 
@@ -91,7 +87,7 @@ JNF_COCOA_ENTER(env);
 
     (*env)->ReleaseIntArrayElements(env, ret, elems, 0);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ret;
 }
@@ -145,21 +141,19 @@ Java_sun_awt_CGraphicsEnvironment_registerDisplayReconfiguration
 {
     jlong ret = 0L;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     JNFWeakJObjectWrapper *wrapper = [[JNFWeakJObjectWrapper wrapperWithJObject:this withEnv:env] retain];
 
     /* Register the callback */
     if (CGDisplayRegisterReconfigurationCallback(&displaycb_handle, wrapper) != kCGErrorSuccess) {
-        [JNFException raise:env
-                         as:kInternalError
-                     reason:"CGDisplayRegisterReconfigurationCallback() failed"];
+        JNU_ThrowInternalError(env, "CGDisplayRegisterReconfigurationCallback() failed");
         return 0L;
     }
 
     ret = ptr_to_jlong(wrapper);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ret;
 }
@@ -173,21 +167,19 @@ JNIEXPORT void JNICALL
 Java_sun_awt_CGraphicsEnvironment_deregisterDisplayReconfiguration
 (JNIEnv *env, jobject this, jlong p)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     JNFWeakJObjectWrapper *wrapper = (JNFWeakJObjectWrapper *)jlong_to_ptr(p);
     if (!wrapper) return;
 
     /* Remove the registration */
     if (CGDisplayRemoveReconfigurationCallback(&displaycb_handle, wrapper) != kCGErrorSuccess) {
-        [JNFException raise:env
-                         as:kInternalError
-                     reason:"CGDisplayRemoveReconfigurationCallback() failed, leaking the callback context!"];
+        JNU_ThrowInternalError(env, "CGDisplayRemoveReconfigurationCallback() failed, leaking the callback context!");
         return;
     }
 
     [wrapper setJObject:NULL withEnv:env]; // more efficient to pre-clear
     [wrapper release];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
@@ -111,7 +111,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromArra
 {
     jlong result = 0L;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSBitmapImageRep* imageRep = CImage_CreateImageRep(env, buffer, width, height);
     if (imageRep) {
@@ -120,7 +120,7 @@ JNF_COCOA_ENTER(env);
         result = ptr_to_jlong(nsImage);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return result;
 }
@@ -135,7 +135,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromArra
 {
     jlong result = 0L;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jsize num = (*env)->GetArrayLength(env, buffers);
     NSMutableArray * reps = [NSMutableArray arrayWithCapacity: num];
@@ -164,7 +164,7 @@ JNF_COCOA_ENTER(env);
         result = ptr_to_jlong(nsImage);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return result;
 }
@@ -179,7 +179,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromIcon
 {
     NSImage *image = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     IconRef iconRef;
     if (noErr == GetIconRef(kOnSystemDisk, kSystemIconsCreator, selector, &iconRef)) {
@@ -187,7 +187,7 @@ JNF_COCOA_ENTER(env);
         ReleaseIconRef(iconRef);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(image);
 }
@@ -202,12 +202,12 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromFile
 {
     NSImage *image = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *path = JNFNormalizedNSStringForPath(env, file);
     image = [[NSImage alloc] initByReferencingFile:path];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(image);
 }
@@ -222,7 +222,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageOfFileFr
 {
     __block NSImage *image = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *path = JNFNormalizedNSStringForPath(env, file);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
@@ -230,7 +230,7 @@ JNF_COCOA_ENTER(env);
         [image setScalesWhenResized:TRUE];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(image);
 }
@@ -245,11 +245,11 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromImag
 {
     NSImage *image = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     image = [[NSImage imageNamed:JNFJavaToNSString(env, name)] retain];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(image);
 }
@@ -263,7 +263,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CImage_nativeCopyNSImageIntoArray
 (JNIEnv *env, jclass klass, jlong nsImgPtr, jintArray buffer, jint sw, jint sh,
                  jint dw, jint dh)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSImage *img = (NSImage *)jlong_to_ptr(nsImgPtr);
     jint *dst = (*env)->GetPrimitiveArrayCritical(env, buffer, NULL);
@@ -274,7 +274,7 @@ JNF_COCOA_ENTER(env);
         (*env)->ReleasePrimitiveArrayCritical(env, buffer, dst, JNI_ABORT);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -287,11 +287,11 @@ JNIEXPORT jobject JNICALL Java_sun_lwawt_macosx_CImage_nativeGetNSImageSize
 {
     jobject size = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     size = NSToJavaSize(env, [(NSImage *)jlong_to_ptr(nsImgPtr) size]);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return size;
 }
@@ -307,12 +307,12 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CImage_nativeSetNSImageSize
     if (!image) return;
     NSImage *i = (NSImage *)jlong_to_ptr(image);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [i setScalesWhenResized:TRUE];
     [i setSize:NSMakeSize(w, h)];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -326,7 +326,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CImage_nativeResizeNSImageRepresent
     if (!image) return;
     NSImage *i = (NSImage *)jlong_to_ptr(image);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSImageRep *imageRep = nil;
     NSArray *imageRepresentations = [i representations];
@@ -335,7 +335,7 @@ JNF_COCOA_ENTER(env);
         [imageRep setSize:NSMakeSize(w, h)];
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 NSComparisonResult getOrder(BOOL order){
@@ -355,7 +355,7 @@ JNIEXPORT jobjectArray JNICALL
     jobjectArray jreturnArray = NULL;
     NSImage *img = (NSImage *)jlong_to_ptr(image);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSArray *imageRepresentations = [img representations];
     if([imageRepresentations count] == 0){
@@ -417,7 +417,7 @@ JNF_COCOA_ENTER(env);
         JNU_CHECK_EXCEPTION_RETURN(env, NULL);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return jreturnArray;
 }
@@ -432,7 +432,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_lwawt_macosx_CImage_nativeGetPlatformImage
 {
     jbyteArray result = 0L;
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSBitmapImageRep* imageRep = CImage_CreateImageRep(env, buffer, width, height);
     if (imageRep) {
@@ -446,7 +446,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_lwawt_macosx_CImage_nativeGetPlatformImage
         (*env)->ReleasePrimitiveArrayCritical(env, result, tiffData, 0);
     }
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return result;
 }
@@ -462,7 +462,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromByte
     jlong result = 0L;
     CHECK_NULL_RETURN(sourceData, 0L);
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     jsize sourceSize = (*env)->GetArrayLength(env, sourceData);
     if (sourceSize == 0) return 0L;
@@ -476,7 +476,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromByte
     CHECK_NULL_RETURN(newImage, 0L);
 
     result = ptr_to_jlong(newImage);
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
     return result;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
@@ -152,7 +152,7 @@ JNIEXPORT jobject JNICALL Java_sun_lwawt_macosx_CInputMethod_nativeGetCurrentInp
     if (!inputMethodController) return NULL;
     jobject returnValue = 0;
     __block NSString *keyboardInfo = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         keyboardInfo = [inputMethodController performSelector:@selector(currentInputMethodName)];
@@ -163,7 +163,7 @@ JNF_COCOA_ENTER(env);
     returnValue = JNFNSToJavaString(env, keyboardInfo);
     [keyboardInfo release];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -175,14 +175,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CInputMethod_nativeNotifyPeer
 (JNIEnv *env, jobject this, jlong nativePeer, jobject inputMethod)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     AWTView *view = (AWTView *)jlong_to_ptr(nativePeer);
     JNFJObjectWrapper *inputMethodWrapper = [[JNFJObjectWrapper alloc] initWithJObject:inputMethod withEnv:env];
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [CInputMethod _nativeNotifyPeerWithView:view inputMethod:inputMethodWrapper];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
 }
 
@@ -194,14 +194,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CInputMethod_nativeEndComposition
 (JNIEnv *env, jobject this, jlong nativePeer)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
    AWTView *view = (AWTView *)jlong_to_ptr(nativePeer);
 
    [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [CInputMethod _nativeEndComposition:view];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -215,7 +215,7 @@ JNIEXPORT jobject JNICALL Java_sun_lwawt_macosx_CInputMethod_getNativeLocale
     if (!inputMethodController) return NULL;
     jobject returnValue = 0;
     __block NSString *isoAbbreviation;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         isoAbbreviation = (NSString *) [inputMethodController performSelector:@selector(currentInputMethodLocale)];
@@ -245,7 +245,7 @@ JNF_COCOA_ENTER(env);
 
     returnValue = sLastKeyboardLocaleObj;
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -258,7 +258,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CInputMethod_setNativeLocale
 (JNIEnv *env, jobject this, jstring locale, jboolean isActivating)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     NSString *localeStr = JNFJavaToNSString(env, locale);
     [localeStr retain];
 
@@ -267,7 +267,7 @@ JNF_COCOA_ENTER(env);
     }];
 
     [localeStr release];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return JNI_TRUE;
 }
 
@@ -299,7 +299,7 @@ JNIEXPORT jobject JNICALL Java_sun_lwawt_macosx_CInputMethodDescriptor_nativeGet
     jobject returnValue = 0;
 
     __block NSArray *selectableArray = nil;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         selectableArray = (NSArray *)[inputMethodController performSelector:@selector(availableInputMethodLocales)];
@@ -327,7 +327,7 @@ JNF_COCOA_ENTER(env);
         (*env)->DeleteLocalRef(env, localeObj);
     }
     [selectableArray release];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenu.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenu.m
@@ -30,6 +30,7 @@
 #import "CMenu.h"
 #import "CMenuBar.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 #import "sun_lwawt_macosx_CMenu.h"
 
@@ -155,7 +156,7 @@ Java_sun_lwawt_macosx_CMenu_nativeCreateSubMenu
 (JNIEnv *env, jobject peer, jlong parentMenu)
 {
     CMenu *aCMenu = nil;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jobject cPeerObjGlobal = (*env)->NewGlobalRef(env, peer);
 
@@ -164,7 +165,7 @@ JNF_COCOA_ENTER(env);
     // Add it to the parent menu
     [((CMenu *)jlong_to_ptr(parentMenu)) addJavaSubmenu: aCMenu];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(aCMenu);
 }
@@ -183,7 +184,7 @@ Java_sun_lwawt_macosx_CMenu_nativeCreateMenu
 {
     CMenu *aCMenu = nil;
     CMenuBar *parent = (CMenuBar *)jlong_to_ptr(parentMenuBar);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jobject cPeerObjGlobal = (*env)->NewGlobalRef(env, peer);
 
@@ -199,7 +200,7 @@ JNF_COCOA_ENTER(env);
         [parent javaSetHelpMenu: aCMenu];
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return ptr_to_jlong(aCMenu);
 }
 
@@ -213,10 +214,10 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenu_nativeSetMenuTitle
 (JNIEnv *env, jobject peer, jlong menuObject, jstring label)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Set the menu's title.
     [((CMenu *)jlong_to_ptr(menuObject)) setJavaMenuTitle:JNFJavaToNSString(env, label)];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -228,10 +229,10 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenu_nativeDeleteItem
 (JNIEnv *env, jobject peer, jlong menuObject, jint index)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Remove the specified item.
     [((CMenu *)jlong_to_ptr(menuObject)) deleteJavaItem: index];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -245,10 +246,10 @@ Java_sun_lwawt_macosx_CMenu_nativeGetNSMenu
 {
     NSMenu* nsMenu = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Strong retain this menu; it'll get released in Java_apple_laf_ScreenMenu_addMenuListeners
     nsMenu = [[((CMenu *)jlong_to_ptr(menuObject)) menu] retain];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(nsMenu);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#import "JNIUtilities.h"
+
 #import <AppKit/AppKit.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
@@ -407,7 +409,7 @@ Java_sun_lwawt_macosx_CMenuBar_nativeCreateMenuBar
     (JNIEnv *env, jobject peer)
 {
     __block CMenuBar *aCMenuBar = nil;
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     jobject cPeerObjGlobal = (*env)->NewGlobalRef(env, peer);
 
@@ -420,7 +422,7 @@ Java_sun_lwawt_macosx_CMenuBar_nativeCreateMenuBar
         return 0L;
     }
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
     return ptr_to_jlong(aCMenuBar);
 }
 
@@ -434,10 +436,10 @@ Java_sun_lwawt_macosx_CMenuBar_nativeAddAtIndex
     (JNIEnv *env, jobject peer,
      jlong menuBarObject, jlong menuObject, jint index)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     // Remove the specified item.
     [((CMenuBar *) jlong_to_ptr(menuBarObject)) javaAddMenu:(CMenu *) jlong_to_ptr(menuObject) atIndex:index];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -449,10 +451,10 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenuBar_nativeDelMenu
     (JNIEnv *env, jobject peer, jlong menuBarObject, jint index)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     // Remove the specified item.
     [((CMenuBar *) jlong_to_ptr(menuBarObject)) javaDeleteMenu: index];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -464,8 +466,8 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenuBar_nativeSetHelpMenu
     (JNIEnv *env, jobject peer, jlong menuBarObject, jlong menuObject)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     // Remove the specified item.
     [((CMenuBar *) jlong_to_ptr(menuBarObject)) javaSetHelpMenu: ((CMenu *)jlong_to_ptr(menuObject))];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
@@ -70,7 +70,7 @@
 - (void)handleAction:(NSMenuItem *)sender {
     AWT_ASSERT_APPKIT_THREAD;
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     // If we are called as a result of user pressing a shortcut, do nothing,
     // because AVTView has already sent corresponding key event to the Java
@@ -111,7 +111,7 @@
         (*env)->CallVoidMethod(env, fPeer, jm_handleAction, UTC(currEvent), javaModifiers); // AWT_THREADING Safe (event)
     }
     CHECK_EXCEPTION();
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 - (void) setJavaLabel:(NSString *)theLabel shortcut:(NSString *)theKeyEquivalent modifierMask:(jint)modifiers {
@@ -312,7 +312,7 @@ Java_sun_lwawt_macosx_CMenuItem_nativeSetLabel
  jlong menuItemObj, jstring label,
  jchar shortcutKey, jint shortcutKeyCode, jint mods)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     NSString *theLabel = JNFJavaToNSString(env, label);
     NSString *theKeyEquivalent = nil;
     unichar macKey = shortcutKey;
@@ -329,7 +329,7 @@ Java_sun_lwawt_macosx_CMenuItem_nativeSetLabel
     }
 
     [((CMenuItem *)jlong_to_ptr(menuItemObj)) setJavaLabel:theLabel shortcut:theKeyEquivalent modifierMask:mods];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -341,10 +341,10 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenuItem_nativeSetTooltip
 (JNIEnv *env, jobject peer, jlong menuItemObj, jstring tooltip)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     NSString *theTooltip = JNFJavaToNSString(env, tooltip);
     [((CMenuItem *)jlong_to_ptr(menuItemObj)) setJavaToolTipText:theTooltip];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -356,9 +356,9 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenuItem_nativeSetImage
 (JNIEnv *env, jobject peer, jlong menuItemObj, jlong image)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     [((CMenuItem *)jlong_to_ptr(menuItemObj)) setJavaImage:(NSImage*)jlong_to_ptr(image)];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -374,7 +374,7 @@ Java_sun_lwawt_macosx_CMenuItem_nativeCreate
     __block CMenuItem *aCMenuItem = nil;
     BOOL asSeparator = (isSeparator == JNI_TRUE) ? YES: NO;
     CMenu *parentCMenu = (CMenu *)jlong_to_ptr(parentCMenuObj);
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     jobject cPeerObjGlobal = (*env)->NewGlobalRef(env, peer);
 
@@ -393,7 +393,7 @@ Java_sun_lwawt_macosx_CMenuItem_nativeCreate
 
     // setLabel will be called after creation completes.
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
     return ptr_to_jlong(aCMenuItem);
 }
 
@@ -406,10 +406,10 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CMenuItem_nativeSetEnabled
 (JNIEnv *env, jobject peer, jlong menuItemObj, jboolean enable)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     CMenuItem *item = (CMenuItem *)jlong_to_ptr(menuItemObj);
     [item setJavaEnabled: (enable == JNI_TRUE)];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -421,10 +421,10 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CCheckboxMenuItem_nativeSetState
 (JNIEnv *env, jobject peer, jlong menuItemObj, jboolean state)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     CMenuItem *item = (CMenuItem *)jlong_to_ptr(menuItemObj);
     [item setJavaState: (state == JNI_TRUE)];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -436,8 +436,8 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CCheckboxMenuItem_nativeSetIsCheckbox
 (JNIEnv *env, jobject peer, jlong menuItemObj)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     CMenuItem *item = (CMenuItem *)jlong_to_ptr(menuItemObj);
     [item setIsCheckbox];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPopupMenu.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPopupMenu.m
@@ -60,7 +60,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CPopupMenu_nativeCreatePopupMenu
 
     __block CPopupMenu *aCPopupMenu = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jobject cPeerObjGlobal = JNFNewGlobalRef(env, peer);
 
@@ -68,7 +68,7 @@ JNF_COCOA_ENTER(env);
         aCPopupMenu = [[CPopupMenu alloc] initWithPeer:cPeerObjGlobal];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(aCPopupMenu);
 }
@@ -76,7 +76,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPopupMenu_nativeShowPopupMenu
 (JNIEnv *env, jobject peer, jlong menuPtr, jint x, jint y) {
 
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     CPopupMenu* cPopupMenu = (CPopupMenu*)jlong_to_ptr(menuPtr);
 
@@ -88,7 +88,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPopupMenu_nativeShowPopupMenu
                                              inView: nil];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -489,12 +489,12 @@ static void javaPrinterJobToNSPrintInfo(JNIEnv* env, jobject srcPrinterJob, jobj
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterJob_abortDoc
   (JNIEnv *env, jobject jthis)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // This is only called during the printLoop from the printLoop thread
     NSPrintOperation* printLoop = [NSPrintOperation currentOperation];
     NSPrintInfo* printInfo = [printLoop printInfo];
     [printInfo setJobDisposition:NSPrintCancelJob];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -505,13 +505,13 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterJob_getDefaultPage
   (JNIEnv *env, jobject jthis, jobject page)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     NSPrintInfo* printInfo = createDefaultNSPrintInfo(env, NULL);
 
     nsPrintInfoToJavaPageFormat(env, printInfo, page);
 
     [printInfo release];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -522,7 +522,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterJob_validatePaper
   (JNIEnv *env, jobject jthis, jobject origpaper, jobject newpaper)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
 
     NSPrintInfo* printInfo = createDefaultNSPrintInfo(env, NULL);
@@ -531,7 +531,7 @@ JNF_COCOA_ENTER(env);
     nsPrintInfoToJavaPaper(env, printInfo, newpaper);
     [printInfo release];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -543,7 +543,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CPrinterJob_createNSPrintInfo
   (JNIEnv *env, jobject jthis)
 {
     jlong result = -1;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // This is used to create the NSPrintInfo for this PrinterJob. Thread
     //  safety is assured by the java side of this call.
 
@@ -551,7 +551,7 @@ JNF_COCOA_ENTER(env);
 
     result = ptr_to_jlong(printInfo);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return result;
 }
 
@@ -563,13 +563,13 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterJob_dispose
   (JNIEnv *env, jobject jthis, jlong nsPrintInfo)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     if (nsPrintInfo != -1)
     {
         NSPrintInfo* printInfo = (NSPrintInfo*)jlong_to_ptr(nsPrintInfo);
         [printInfo release];
     }
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 
@@ -591,7 +591,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJob_printLoop
 
     jboolean retVal = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Get the first page's PageFormat for setting things up (This introduces
     //  and is a facet of the same problem in Radar 2818593/2708932).
     jobject page = (*env)->CallObjectMethod(env, jthis, jm_getPageFormat, 0); // AWT_THREADING Safe (!appKit)
@@ -647,7 +647,7 @@ JNF_COCOA_ENTER(env);
             (*env)->DeleteLocalRef(env, pageFormatArea);
         }
     }
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return retVal;
 }
 
@@ -664,7 +664,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterPageDialog_showDialog
     DECLARE_FIELD_RETURN(jm_page, jc_CPrinterPageDialog, "fPage", "Ljava/awt/print/PageFormat;", NO);
 
     jboolean result = JNI_FALSE;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     GET_CPRINTERDIALOG_FIELD_RETURN(NO);
     GET_NSPRINTINFO_METHOD_RETURN(NO)
     jobject printerJob = (*env)->GetObjectField(env, jthis, sjm_printerJob);
@@ -698,7 +698,7 @@ JNF_COCOA_ENTER(env);
         (*env)->DeleteLocalRef(env, page);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return result;
 }
 
@@ -714,7 +714,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPrinterJobDialog_showDialog
     DECLARE_FIELD_RETURN(jm_pageable, jc_CPrinterJobDialog, "fPageable", "Ljava/awt/print/Pageable;", NO);
 
     jboolean result = JNI_FALSE;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     GET_CPRINTERDIALOG_FIELD_RETURN(NO);
     jobject printerJob = (*env)->GetObjectField(env, jthis, sjm_printerJob);
     if (printerJob == NULL) return NO;
@@ -745,6 +745,6 @@ JNF_COCOA_ENTER(env);
         (*env)->DeleteLocalRef(env, pageable);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return result;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -23,7 +23,7 @@
  * questions.
  */
 
-#import "jni_util.h"
+#import "JNIUtilities.h"
 
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <ApplicationServices/ApplicationServices.h>
@@ -168,7 +168,7 @@ Java_sun_lwawt_macosx_CRobot_mouseEvent
 (JNIEnv *env, jobject peer, jint mouseLastX, jint mouseLastY, jint buttonsState,
  jboolean isButtonsDownState, jboolean isMouseMove)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     autoDelay(isMouseMove);
 
     // This is the native method called when Robot mouse events occur.
@@ -254,7 +254,7 @@ Java_sun_lwawt_macosx_CRobot_mouseEvent
 
     PostMouseEvent(point, button, type, clickCount, eventNumber);
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -316,7 +316,7 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
 (JNIEnv *env, jobject peer,
  jint x, jint y, jint width, jint height, jdouble scale, jintArray pixels)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     jint picX = x;
     jint picY = y;
@@ -362,7 +362,7 @@ Java_sun_lwawt_macosx_CRobot_nativeGetScreenPixels
     // release the Java int array back up to the JVM
     (*env)->ReleasePrimitiveArrayCritical(env, pixels, jPixelData, 0);
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /****************************************************

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -41,10 +41,10 @@ NSColor **appleColors = nil;
 
 + (void)initialize {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [CSystemColors reloadColors];
     [[NSNotificationCenter defaultCenter] addObserver:[CSystemColors class] selector:@selector(systemColorsDidChange:) name:NSSystemColorsDidChangeNotification object:nil];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTextPipe.m
@@ -589,7 +589,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTextPipe_doDrawString
     QuartzSDOps *qsdo = (QuartzSDOps *)SurfaceData_GetOps(env, jsurfacedata);
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jsize len = (*env)->GetStringLength(env, str);
 
@@ -613,7 +613,7 @@ JNF_COCOA_ENTER(env);
         JNFReleaseStringUTF16UniChars(env, str, unichars);
     }
 
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 
@@ -628,7 +628,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTextPipe_doUnicodes
     QuartzSDOps *qsdo = (QuartzSDOps *)SurfaceData_GetOps(env, jsurfacedata);
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     // Setup the text context
     if (length < MAX_STACK_ALLOC_GLYPH_BUFFER_SIZE) // optimized for stack allocation
@@ -642,7 +642,8 @@ JNF_COCOA_ENTER(env);
     {
         jchar *copyUnichars = malloc(length * sizeof(jchar));
         if (!copyUnichars) {
-            [JNFException raise:env as:kOutOfMemoryError reason:"Failed to malloc memory to create the glyphs for string drawing"];
+            JNU_ThrowOutOfMemoryError(env, "Failed to malloc memory to create the glyphs for string drawing");
+            return;
         }
 
         @try {
@@ -654,7 +655,7 @@ JNF_COCOA_ENTER(env);
         }
     }
 
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -668,11 +669,11 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTextPipe_doOneUnicode
     QuartzSDOps *qsdo = (QuartzSDOps *)SurfaceData_GetOps(env, jsurfacedata);
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     DrawTextContext(env, qsdo, awtStrike, &aUnicode, 1, x, y);
 
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -686,7 +687,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTextPipe_doDrawGlyphs
     QuartzSDOps *qsdo = (QuartzSDOps *)SurfaceData_GetOps(env, jsurfacedata);
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     qsdo->BeginSurface(env, qsdo, SD_Text);
     if (qsdo->cgRef == NULL)
@@ -704,5 +705,5 @@ JNF_COCOA_ENTER(env);
 
     qsdo->FinishSurface(env, qsdo);
 
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
@@ -333,14 +333,14 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CTrayIcon_nativeCreate
 (JNIEnv *env, jobject peer) {
     __block AWTTrayIcon *trayIcon = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jobject thePeer = JNFNewGlobalRef(env, peer);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         trayIcon = [[AWTTrayIcon alloc] initWithPeer:thePeer];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(trayIcon);
 }
@@ -363,7 +363,7 @@ JNIEXPORT void JNICALL Java_java_awt_TrayIcon_initIDs
  */
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTrayIcon_nativeSetToolTip
 (JNIEnv *env, jobject self, jlong model, jstring jtooltip) {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTTrayIcon *icon = jlong_to_ptr(model);
     NSString *tooltip = JNFJavaToNSString(env, jtooltip);
@@ -371,7 +371,7 @@ JNF_COCOA_ENTER(env);
         [icon setTooltip:tooltip];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -381,14 +381,14 @@ JNF_COCOA_EXIT(env);
  */
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTrayIcon_setNativeImage
 (JNIEnv *env, jobject self, jlong model, jlong imagePtr, jboolean autosize) {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTTrayIcon *icon = jlong_to_ptr(model);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         [icon setImage:jlong_to_ptr(imagePtr) sizing:autosize];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT jobject JNICALL
@@ -396,7 +396,7 @@ Java_sun_lwawt_macosx_CTrayIcon_nativeGetIconLocation
 (JNIEnv *env, jobject self, jlong model) {
     jobject jpt = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     __block NSPoint pt = NSZeroPoint;
     AWTTrayIcon *icon = jlong_to_ptr(model);
@@ -407,7 +407,7 @@ JNF_COCOA_ENTER(env);
 
     jpt = NSToJavaPoint(env, pt);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return jpt;
 }
@@ -416,7 +416,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CTrayIcon_nativeShowNotification
 (JNIEnv *env, jobject self, jlong model, jobject jcaption, jobject jtext,
               long nsimage) {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTTrayIcon *icon = jlong_to_ptr(model);
     NSString *caption = JNFJavaToNSString(env, jcaption);
@@ -434,5 +434,5 @@ JNF_COCOA_ENTER(env);
             deliverNotification:notification];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#import "JNIUtilities.h"
+
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import "ThreadUtilities.h"
 #import "sun_lwawt_macosx_CWrapper_NSWindow.h"
@@ -36,7 +38,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_makeKeyAndOrderFront
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(makeKeyAndOrderFront:)
@@ -44,7 +46,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -56,7 +58,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_makeKeyWindow
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(makeKeyWindow)
@@ -64,7 +66,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -76,7 +78,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_makeMainWindow
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(makeMainWindow)
@@ -84,7 +86,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -98,14 +100,14 @@ Java_sun_lwawt_macosx_CWrapper_00024NSWindow_canBecomeMainWindow
 {
     __block jboolean canBecomeMainWindow = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         canBecomeMainWindow = [window canBecomeMainWindow];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return canBecomeMainWindow;
 }
@@ -121,14 +123,14 @@ Java_sun_lwawt_macosx_CWrapper_00024NSWindow_isKeyWindow
 {
     __block jboolean isKeyWindow = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         isKeyWindow = [window isKeyWindow];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return isKeyWindow;
 }
@@ -142,7 +144,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_orderFront
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(orderFront:)
@@ -150,7 +152,7 @@ JNF_COCOA_ENTER(env);
                               withObject:window
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -162,7 +164,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_orderOut
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(orderOut:)
@@ -170,7 +172,7 @@ JNF_COCOA_ENTER(env);
                               withObject:window
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -182,12 +184,12 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_close
         (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [window close];
     }];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -199,7 +201,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_orderFrontRegardless
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(orderFrontRegardless)
@@ -207,7 +209,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -219,7 +221,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_orderWindow
 (JNIEnv *env, jclass cls, jlong windowPtr, jint order, jlong relativeToPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     NSWindow *relativeTo = (NSWindow *)jlong_to_ptr(relativeToPtr);
@@ -227,7 +229,7 @@ JNF_COCOA_ENTER(env);
         [window orderWindow:(NSWindowOrderingMode)order relativeTo:[relativeTo windowNumber]];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 // Used for CWrapper.NSWindow.setLevel() (and level() which isn't implemented yet)
@@ -252,7 +254,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_setLevel
 (JNIEnv *env, jclass cls, jlong windowPtr, jint level)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     if (level >= 0 && level < sun_lwawt_macosx_CWrapper_NSWindow_MAX_WINDOW_LEVELS) {
         initLevels();
@@ -262,10 +264,10 @@ JNF_COCOA_ENTER(env);
             [window setLevel: LEVELS[level]];
         }];
     } else {
-        [JNFException raise:env as:kIllegalArgumentException reason:"unknown level"];
+        JNU_ThrowIllegalArgumentException(env, "unknown level");
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -277,7 +279,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_addChildWindow
 (JNIEnv *env, jclass cls, jlong parentPtr, jlong childPtr, jint order)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *parent = (NSWindow *)jlong_to_ptr(parentPtr);
     NSWindow *child = (NSWindow *)jlong_to_ptr(childPtr);
@@ -285,7 +287,7 @@ JNF_COCOA_ENTER(env);
         [parent addChildWindow:child ordered:order];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -297,7 +299,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_removeChildWindow
 (JNIEnv *env, jclass cls, jlong parentPtr, jlong childPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *parent = (NSWindow *)jlong_to_ptr(parentPtr);
     NSWindow *child = (NSWindow *)jlong_to_ptr(childPtr);
@@ -306,7 +308,7 @@ JNF_COCOA_ENTER(env);
                               withObject:child
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -318,14 +320,14 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_setAlphaValue
 (JNIEnv *env, jclass cls, jlong windowPtr, jfloat alpha)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [window setAlphaValue:(CGFloat)alpha];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -337,14 +339,14 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_setOpaque
 (JNIEnv *env, jclass cls, jlong windowPtr, jboolean opaque)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [window setOpaque:(BOOL)opaque];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -356,7 +358,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_setBackgroundColor
 (JNIEnv *env, jclass cls, jlong windowPtr, jint rgb)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     CGFloat alpha = (((rgb >> 24) & 0xff) / 255.0);
@@ -369,7 +371,7 @@ JNF_COCOA_ENTER(env);
         [window setBackgroundColor:color];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -381,7 +383,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_miniaturize
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(miniaturize:)
@@ -389,7 +391,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -401,7 +403,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_deminiaturize
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(deminiaturize:)
@@ -409,7 +411,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -423,14 +425,14 @@ Java_sun_lwawt_macosx_CWrapper_00024NSWindow_isZoomed
 {
     __block jboolean isZoomed = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         isZoomed = [window isZoomed];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return isZoomed;
 }
@@ -444,7 +446,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_zoom
 (JNIEnv *env, jclass cls, jlong windowPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     [ThreadUtilities performOnMainThread:@selector(zoom:)
@@ -452,7 +454,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -464,7 +466,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSWindow_makeFirstResponder
 (JNIEnv *env, jclass cls, jlong windowPtr, jlong responderPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSWindow *window = (NSWindow *)jlong_to_ptr(windowPtr);
     NSResponder *responder = (NSResponder *)jlong_to_ptr(responderPtr);
@@ -473,7 +475,7 @@ JNF_COCOA_ENTER(env);
                               withObject:responder
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -485,7 +487,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSView_addSubview
 (JNIEnv *env, jclass cls, jlong viewPtr, jlong subviewPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     NSView *subview = (NSView *)jlong_to_ptr(subviewPtr);
@@ -493,7 +495,7 @@ JNF_COCOA_ENTER(env);
         [view addSubview:subview];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -505,7 +507,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSView_removeFromSuperview
 (JNIEnv *env, jclass cls, jlong viewPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     [ThreadUtilities performOnMainThread:@selector(removeFromSuperview)
@@ -513,7 +515,7 @@ JNF_COCOA_ENTER(env);
                               withObject:nil
                            waitUntilDone:NO];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -525,14 +527,14 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSView_setFrame
 (JNIEnv *env, jclass cls, jlong viewPtr, jint x, jint y, jint w, jint h)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [view setFrame:NSMakeRect(x, y, w, h)];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -546,14 +548,14 @@ Java_sun_lwawt_macosx_CWrapper_00024NSView_window
 {
     __block jlong windowPtr = 0L;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         windowPtr = ptr_to_jlong([view window]);
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return windowPtr;
 }
@@ -567,14 +569,14 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_CWrapper_00024NSView_setHidden
 (JNIEnv *env, jclass cls, jlong viewPtr, jboolean toHide)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [view setHidden:(BOOL)toHide];
     }];
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -587,7 +589,7 @@ Java_sun_lwawt_macosx_CWrapper_00024NSView_setToolTip
 (JNIEnv *env, jclass cls, jlong viewPtr, jstring msg)
 {
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
     NSString* s = JNFJavaToNSString(env, msg);
@@ -595,5 +597,5 @@ JNF_COCOA_ENTER(env);
         [view setToolTip: s];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
@@ -1241,7 +1241,7 @@ PRINT("xorSurfacePixels")
 
     jboolean handled = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     ImageSDOps* srcIsdo = LockImagePixels(env, srcIsd);
     ImageSDOps* dstIsdo = LockImagePixels(env, dstIsd);
 
@@ -1320,7 +1320,7 @@ fprintf(stderr, "   dstIsdo->width=%d, dstIsdo->height=%d, biqsdoPixels->width=%
     UnlockImagePixels(env, srcIsdo);
     UnlockImagePixels(env, dstIsdo);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return handled;
 }
 
@@ -1329,7 +1329,7 @@ IMAGE_SURFACE_INLINE jboolean clearSurfacePixels(JNIEnv *env, jobject bisd, jint
 PRINT("clearSurfacePixels")
     jboolean handled = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     ImageSDOps *isdo = LockImagePixels(env, bisd);
 
@@ -1361,7 +1361,7 @@ JNF_COCOA_ENTER(env);
     }
     UnlockImagePixels(env, isdo);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return handled;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1500,9 +1500,9 @@ static NSObject *sAttributeNamesLOCK = nil;
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessibility_focusChanged
 (JNIEnv *env, jobject jthis)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postFocusChanged:) on:[JavaComponentAccessibility class] withObject:nil waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1513,9 +1513,9 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_valueChanged
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postValueChanged) on:(JavaComponentAccessibility *)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1526,12 +1526,12 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_selectedTextChanged
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postSelectedTextChanged)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1542,9 +1542,9 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_selectionChanged
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postSelectionChanged) on:(JavaComponentAccessibility *)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1555,9 +1555,9 @@ JNF_COCOA_EXIT(env);
  JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_titleChanged
  (JNIEnv *env, jclass jklass, jlong element)
  {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postTitleChanged) on:(JavaComponentAccessibility*)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
  }
 
 /*
@@ -1568,12 +1568,12 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuOpened
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postMenuOpened)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1584,12 +1584,12 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuClosed
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postMenuClosed)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1600,12 +1600,12 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_menuItemSelected
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(postMenuItemSelected)
                      on:(JavaComponentAccessibility *)jlong_to_ptr(element)
                      withObject:nil
                      waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -1616,9 +1616,9 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CAccessible_unregisterFromCocoaAXSystem
 (JNIEnv *env, jclass jklass, jlong element)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThread:@selector(unregisterFromCocoaAXSystem) on:(JavaComponentAccessibility *)jlong_to_ptr(element) withObject:nil waitUntilDone:NO];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 @implementation TabGroupAccessibility

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -474,9 +474,9 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_LWCToolkit_nativeSyncQueue
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_LWCToolkit_flushNativeSelectors
 (JNIEnv *env, jclass clz)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         [ThreadUtilities performOnMainThreadWaiting:YES block:^(){}];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -541,11 +541,11 @@ BOOL doLoadNativeColors(JNIEnv *env, jintArray jColors, BOOL useAppleColors) {
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_LWCToolkit_loadNativeColors
 (JNIEnv *env, jobject peer, jintArray jSystemColors, jintArray jAppleColors)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     if (doLoadNativeColors(env, jSystemColors, NO)) {
         doLoadNativeColors(env, jAppleColors, YES);
     }
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -560,11 +560,11 @@ AWT_ASSERT_APPKIT_THREAD;
 
     jlong result;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // We double retain because this object is owned by both main thread and "other" thread
     // We release in both doAWTRunLoop and stopAWTRunLoop
     result = ptr_to_jlong([[[AWTRunLoopObject alloc] init] retain]);
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return result;
 }
@@ -578,7 +578,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_LWCToolkit_doAWTRunLoopImpl
 (JNIEnv *env, jclass clz, jlong mediator, jboolean processEvents, jboolean inAWT)
 {
 AWT_ASSERT_APPKIT_THREAD;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTRunLoopObject* mediatorObject = (AWTRunLoopObject*)jlong_to_ptr(mediator);
 
@@ -604,7 +604,7 @@ JNF_COCOA_ENTER(env);
         }
     }
     [mediatorObject release];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -615,7 +615,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_LWCToolkit_stopAWTRunLoop
 (JNIEnv *env, jclass clz, jlong mediator)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTRunLoopObject* mediatorObject = (AWTRunLoopObject*)jlong_to_ptr(mediator);
 
@@ -623,7 +623,7 @@ JNF_COCOA_ENTER(env);
 
     [mediatorObject release];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -634,14 +634,14 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_LWCToolkit_performOnMainThreadAfterDelay
 (JNIEnv *env, jclass clz, jobject runnable, jlong delay)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     jobject gRunnable = (*env)->NewGlobalRef(env, runnable);
     CHECK_NULL(gRunnable);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^() {
         JavaRunnable* performer = [[JavaRunnable alloc] initWithRunnable:gRunnable];
         [performer performSelector:@selector(perform) withObject:nil afterDelay:(delay/1000.0)];
     }];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 
@@ -672,13 +672,13 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_LWCToolkit_isApplicationActive
 {
     __block jboolean active = JNI_FALSE;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
         active = (jboolean)[NSRunningApplication currentApplication].active;
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return active;
 }
@@ -691,13 +691,13 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_LWCToolkit_activateApplicationIgnoringOtherApps
 (JNIEnv *env, jclass clazz)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         if(![NSApp isActive]){
             [NSApp activateIgnoringOtherApps:YES];
         }
     }];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 
@@ -748,7 +748,7 @@ JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_LWCToolkit_initIDs
 (JNIEnv *env, jclass klass) {
 
-    JNF_COCOA_ENTER(env)
+    JNI_COCOA_ENTER(env);
 
     gNumberOfButtons = sun_lwawt_macosx_LWCToolkit_BUTTONS;
 
@@ -777,7 +777,7 @@ Java_sun_lwawt_macosx_LWCToolkit_initIDs
     (*env)->ReleaseIntArrayElements(env, obj, tmp, 0);
     (*env)->DeleteLocalRef(env, obj);
 
-    JNF_COCOA_EXIT(env)
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -788,7 +788,7 @@ Java_sun_lwawt_macosx_LWCToolkit_initIDs
 JNIEXPORT void JNICALL
 Java_sun_lwawt_macosx_LWCToolkit_initAppkit
 (JNIEnv *env, jclass klass, jobject appkitThreadGroup, jboolean headless) {
-    JNF_COCOA_ENTER(env)
+    JNI_COCOA_ENTER(env);
 
     [ThreadUtilities setAppkitThreadGroup:(*env)->NewGlobalRef(env, appkitThreadGroup)];
 
@@ -806,7 +806,7 @@ Java_sun_lwawt_macosx_LWCToolkit_initAppkit
 
     [AWTStarter start:headless ? YES : NO];
 
-    JNF_COCOA_EXIT(env)
+    JNI_COCOA_EXIT(env);
 }
 
 JNIEXPORT jint JNICALL DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -868,10 +868,10 @@ Java_sun_awt_PlatformGraphicsInfo_isInAquaSession
 JNIEXPORT jint JNICALL
 Java_sun_lwawt_macosx_LWCToolkit_getMultiClickTime(JNIEnv *env, jclass klass) {
     __block jint multiClickTime = 0;
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
         multiClickTime = (jint)([NSEvent doubleClickInterval] * 1000);
     }];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
     return multiClickTime;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrintModel.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrintModel.m
@@ -127,7 +127,7 @@ AWT_ASSERT_NOT_APPKIT_THREAD;
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterJob__1safePrintLoop
 (JNIEnv *env, jclass clz, jlong target, jlong view)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     PrintModel *model = (PrintModel *)jlong_to_ptr(target);
     PrinterView *arg = (PrinterView *)jlong_to_ptr(view);
@@ -138,6 +138,6 @@ JNF_COCOA_ENTER(env);
     [model release];
     [arg release];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterSurfaceData.m
@@ -83,7 +83,7 @@ PRINT(" PrintSD_dispose")
 
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPrinterSurfaceData_initOps(JNIEnv *env, jobject jthis, jlong nsRef, jobject jGraphicsState, jobjectArray jGraphicsStateObject, jint width, jint height)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
 PRINT("Java_sun_lwawt_macosx_CPrinterSurfaceData_initOps")
 
@@ -116,7 +116,7 @@ PRINT("Java_sun_lwawt_macosx_CPrinterSurfaceData_initOps")
     sdo->Setup        = NULL;
     sdo->Dispose    = PrintSD_dispose;
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 static jint PrintSD_Lock(JNIEnv *env, SurfaceDataOps *sdo, SurfaceDataRasInfo *pRasInfo, jint lockflags)

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzRenderer.m
@@ -636,7 +636,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doLine
 {
 PRINT("Java_sun_java2d_CRenderer_doLine")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     SDRenderType renderType = SD_Stroke;
     qsdo->BeginSurface(env, qsdo, renderType);
     if (qsdo->cgRef != NULL)
@@ -644,7 +644,7 @@ JNF_COCOA_ENTER(env);
         doLine(qsdo, x1, y1, x2, y2);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -657,7 +657,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doRect
 {
 PRINT("Java_sun_java2d_CRenderer_doRect")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     SDRenderType renderType    = (isfill? SD_Fill : SD_Stroke);
     qsdo->BeginSurface(env, qsdo, renderType);
     if (qsdo->cgRef != NULL)
@@ -665,7 +665,7 @@ JNF_COCOA_ENTER(env);
         doRect(qsdo, x, y, w, h, isfill);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -678,7 +678,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doRoundRect
 {
 PRINT("Java_sun_java2d_CRenderer_doRoundRect")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     SDRenderType renderType    = (isfill? SD_Fill : SD_Stroke);
     qsdo->BeginSurface(env, qsdo, renderType);
     if (qsdo->cgRef != NULL)
@@ -686,7 +686,7 @@ JNF_COCOA_ENTER(env);
         doRoundRect(qsdo, x, y, w, h, arcWidth, arcHeight, isfill);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -699,7 +699,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doOval
 {
 PRINT("Java_sun_java2d_CRenderer_doOval")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     SDRenderType renderType    = (isfill? SD_Fill : SD_Stroke);
     qsdo->BeginSurface(env, qsdo, renderType);
     if (qsdo->cgRef != NULL)
@@ -707,7 +707,7 @@ JNF_COCOA_ENTER(env);
         doOval(qsdo, x, y, w, h, isfill);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -720,7 +720,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doArc
 {
 PRINT("Java_sun_java2d_CRenderer_doArc")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     SDRenderType renderType    = (isfill? SD_Fill : SD_Stroke);
     qsdo->BeginSurface(env, qsdo, renderType);
     if (qsdo->cgRef != NULL)
@@ -728,7 +728,7 @@ JNF_COCOA_ENTER(env);
         doArc(qsdo, x, y, w, h, angleStart, angleExtent, arcType, isfill);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -741,7 +741,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doPoly
 {
 PRINT("Java_sun_java2d_CRenderer_doPoly")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     BOOL eoFill = YES; // polys are WIND_EVEN_ODD by definition
     SDRenderType renderType    = (isfill? (eoFill ? SD_EOFill : SD_Fill) : SD_Stroke);
     qsdo->BeginSurface(env, qsdo, renderType);
@@ -750,7 +750,7 @@ JNF_COCOA_ENTER(env);
         doPoly(env, qsdo, xpointsarray, ypointsarray, npoints, ispolygon, isfill);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 /*
@@ -763,7 +763,7 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doShape
 {
 PRINT("Java_sun_java2d_CRenderer_doShape")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     BOOL eoFill = (windingRule == java_awt_geom_PathIterator_WIND_EVEN_ODD);
     SDRenderType renderType    = (isfill? (eoFill ? SD_EOFill : SD_Fill) : SD_Stroke);
     qsdo->BeginSurface(env, qsdo, renderType);
@@ -774,7 +774,7 @@ JNF_COCOA_ENTER(env);
         doShape(qsdo, types, coordinates, length, isfill, shouldApplyOffset);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }
 
 #define invalidContext(c) \
@@ -790,12 +790,12 @@ JNIEXPORT void JNICALL Java_sun_java2d_CRenderer_doImage
 {
 PRINT("Java_sun_java2d_CRenderer_doImage")
     QuartzSDOps *qsdo = (QuartzSDOps*)SurfaceData_GetOps(env, jsurfacedata);
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     qsdo->BeginSurface(env, qsdo, SD_Image);
     if (qsdo->cgRef != NULL)
     {
         doImage(env, qsdo, imageSurfaceData, fliph, flipv, w, h, sx, sy, sw, sh, dx, dy, dw, dh);
     }
     qsdo->FinishSurface(env, qsdo);
-JNF_COCOA_RENDERER_EXIT(env);
+JNI_COCOA_RENDERER_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.h
@@ -27,6 +27,7 @@
 #import "BufImgSurfaceData.h"
 #import "AWTFont.h"
 #import <Cocoa/Cocoa.h>
+#import "JNIUtilities.h"
 
 // these flags are not defined on Tiger on PPC, so we need to make them a no-op
 #if !defined(kCGBitmapByteOrder32Host)
@@ -150,10 +151,5 @@ void CompleteCGContext(JNIEnv *env, QuartzSDOps *qsdo);
 
 NSColor* ByteParametersToNSColor(JNIEnv* env, jint *javaGraphicsStates, NSColor* defColor);
 
-#define JNF_COCOA_RENDERER_EXIT(env) \
-} @catch(NSException *localException) { \
-    qsdo->FinishSurface(env, qsdo); \
-    [JNFException throwToJava:env exception:localException]; \
-} \
-        if (_token) JNFNativeMethodExit(_token); \
-}
+#define JNI_COCOA_RENDERER_EXIT(env) \
+ JNI_COCOA_EXIT_WITH_ACTION(env, qsdo->FinishSurface(env, qsdo))

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
@@ -49,6 +49,12 @@
 
 #define kOffset (0.5f)
 
+#define JNI_COCOA_THROW_OOME(env, msg) \
+    if ([NSThread isMainThread] == NO) { \
+         JNU_ThrowOutOfMemoryError(env, msg); \
+    } \
+    [NSException raise:@"Java Exception" reason:@"Java OutOfMemoryException" userInfo:nil]
+
 BOOL gAdjustForJavaDrawing;
 
 #pragma mark
@@ -914,7 +920,7 @@ void setupGradient(JNIEnv *env, QuartzSDOps* qsdo, jfloat* javaFloatGraphicsStat
     qsdo->gradientInfo = (StateGradientInfo*)malloc(sizeof(StateGradientInfo));
     if (qsdo->gradientInfo == NULL)
     {
-        [JNFException raise:env as:kOutOfMemoryError reason:"Failed to malloc memory for gradient paint"];
+        JNI_COCOA_THROW_OOME(env, "Failed to malloc memory for gradient paint");
     }
 
     qsdo->graphicsStateInfo.simpleStroke = NO;
@@ -1015,7 +1021,7 @@ SDRenderType SetUpPaint(JNIEnv *env, QuartzSDOps *qsdo, SDRenderType renderType)
             qsdo->shadingInfo = (StateShadingInfo*)malloc(sizeof(StateShadingInfo));
             if (qsdo->shadingInfo == NULL)
             {
-                [JNFException raise:env as:kOutOfMemoryError reason:"Failed to malloc memory for gradient paint"];
+                JNI_COCOA_THROW_OOME(env, "Failed to malloc memory for gradient paint");
             }
 
             qsdo->graphicsStateInfo.simpleStroke = NO;
@@ -1061,7 +1067,7 @@ SDRenderType SetUpPaint(JNIEnv *env, QuartzSDOps *qsdo, SDRenderType renderType)
             qsdo->patternInfo = (StatePatternInfo*)malloc(sizeof(StatePatternInfo));
             if (qsdo->patternInfo == NULL)
             {
-                [JNFException raise:env as:kOutOfMemoryError reason:"Failed to malloc memory for texture paint"];
+                JNI_COCOA_THROW_OOME(env, "Failed to malloc memory for texture paint");
             }
 
             qsdo->graphicsStateInfo.simpleStroke = NO;

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
@@ -302,7 +302,7 @@ Java_sun_font_CFontManager_loadNativeFonts
 
     jint num = 0;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSArray *filteredFonts = GetFilteredFonts();
     num = (jint)[filteredFonts count];
@@ -320,7 +320,7 @@ JNF_COCOA_ENTER(env);
         (*env)->DeleteLocalRef(env, jFontFamilyName);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -332,7 +332,7 @@ JNIEXPORT void JNICALL
 Java_sun_font_CFontManager_loadNativeDirFonts
 (JNIEnv *env, jclass clz, jstring filename)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *path = JNFJavaToNSString(env, filename);
     NSURL *url = [NSURL fileURLWithPath:(NSString *)path];
@@ -342,7 +342,7 @@ JNF_COCOA_ENTER(env);
     NSLog(@"url is : %@", (NSString*)url);
     printf("res is %d\n", res);
 #endif
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 #pragma mark --- sun.font.CFont JNI ---
@@ -372,7 +372,7 @@ Java_sun_font_CFont_getTableBytesNative
      jlong awtFontPtr, jint jtag)
 {
     jbyteArray jbytes = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CTFontTableTag tag = (CTFontTableTag)jtag;
     int i, found = 0;
@@ -414,7 +414,7 @@ JNF_COCOA_ENTER(env);
                                (jbyte*)tableBytes);
     CFRelease(table);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return jbytes;
 }
@@ -431,7 +431,7 @@ Java_sun_font_CFont_createNativeFont
 {
     AWTFont *awtFont = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     awtFont =
         [AWTFont awtFontForName:JNFJavaToNSString(env, nativeFontName)
@@ -441,7 +441,7 @@ JNF_COCOA_ENTER(env);
         CFRetain(awtFont); // GC
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(awtFont);
 }
@@ -456,7 +456,7 @@ Java_sun_font_CFont_getWidthNative
     (JNIEnv *env, jobject cfont, jlong awtFontPtr)
 {
     float widthVal;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTFont *awtFont = (AWTFont *)jlong_to_ptr(awtFontPtr);
     NSFont* nsFont = awtFont->fFont;
@@ -465,7 +465,7 @@ JNF_COCOA_ENTER(env);
     NSNumber *width = [fontTraits objectForKey : NSFontWidthTrait];
     widthVal = (float)[width floatValue];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
    return (jfloat)widthVal;
 }
 
@@ -479,7 +479,7 @@ Java_sun_font_CFont_getWeightNative
     (JNIEnv *env, jobject cfont, jlong awtFontPtr)
 {
     float weightVal;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTFont *awtFont = (AWTFont *)jlong_to_ptr(awtFontPtr);
     NSFont* nsFont = awtFont->fFont;
@@ -488,7 +488,7 @@ JNF_COCOA_ENTER(env);
     NSNumber *weight = [fontTraits objectForKey : NSFontWeightTrait];
     weightVal = (float)[weight floatValue];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
    return (jfloat)weightVal;
 }
 
@@ -501,13 +501,13 @@ JNIEXPORT void JNICALL
 Java_sun_font_CFont_disposeNativeFont
     (JNIEnv *env, jclass clazz, jlong awtFontPtr)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     if (awtFontPtr) {
         CFRelease((AWTFont *)jlong_to_ptr(awtFontPtr)); // GC
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
@@ -104,7 +104,7 @@ static CGAffineTransform sInverseTX = { 1, 0, 0, -1, 0, 0 };
     if (_fontThrowJavaException == YES) {                               \
         char s[512];                                                    \
         sprintf(s, "%s-%s:%d", __FILE__, __FUNCTION__, __LINE__);       \
-        [JNFException raise:env as:kRuntimeException reason:s];         \
+        JNU_ThrowByName(env, "java/lang/RuntimeException", s);          \
     }
 
 
@@ -144,7 +144,7 @@ Java_sun_font_CStrike_getNativeGlyphAdvance
     (JNIEnv *env, jclass clazz, jlong awtStrikePtr, jint glyphCode)
 {
     CGSize advance;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
     AWTFont *awtFont = awtStrike->fAWTFont;
 
@@ -159,7 +159,7 @@ JNF_COCOA_ENTER(env);
         advance.width = round(advance.width);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return advance.width;
 }
 
@@ -174,7 +174,7 @@ Java_sun_font_CStrike_getNativeGlyphImageBounds
      jlong awtStrikePtr, jint glyphCode,
      jobject result /*Rectangle*/, jdouble x, jdouble y)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
     AWTFont *awtFont = awtStrike->fAWTFont;
@@ -203,7 +203,7 @@ JNF_COCOA_ENTER(env);
              (jfloat)bbox.origin.x, (jfloat)bbox.origin.y, (jfloat)bbox.size.width, (jfloat)bbox.size.height);
     CHECK_EXCEPTION();
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -218,7 +218,7 @@ Java_sun_font_CStrike_getNativeGlyphOutline
 {
     jobject generalPath = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTPathRef path = NULL;
     jfloatArray pointCoords = NULL;
@@ -290,7 +290,7 @@ cleanup:
     }
 
     AWT_FONT_CLEANUP_FINISH;
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return generalPath;
 }
 
@@ -305,7 +305,7 @@ Java_sun_font_CStrike_getGlyphImagePtrsNative
      jlong awtStrikePtr, jlongArray glyphInfoLongArray,
      jintArray glyphCodes, jint len)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTStrike *awtStrike = (AWTStrike *)jlong_to_ptr(awtStrikePtr);
 
@@ -333,7 +333,7 @@ JNF_COCOA_ENTER(env);
         }
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -345,7 +345,7 @@ JNIEXPORT jlong JNICALL Java_sun_font_CStrike_createNativeStrikePtr
 (JNIEnv *env, jclass clazz, jlong nativeFontPtr, jdoubleArray glyphTxArray, jdoubleArray invDevTxArray, jint aaStyle, jint fmHint)
 {
     AWTStrike *awtStrike = nil;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTFont *awtFont = (AWTFont *)jlong_to_ptr(nativeFontPtr);
     JRSFontRenderingStyle style = JRSFontGetRenderingStyleForHints(fmHint, aaStyle);
@@ -360,7 +360,7 @@ JNF_COCOA_ENTER(env);
         CFRetain(awtStrike); // GC
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return ptr_to_jlong(awtStrike);
 }
 
@@ -373,13 +373,13 @@ JNIEXPORT void JNICALL
 Java_sun_font_CStrike_disposeNativeStrikePtr
     (JNIEnv *env, jclass clazz, jlong awtStrike)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     if (awtStrike) {
         CFRelease((AWTStrike *)jlong_to_ptr(awtStrike)); // GC
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -393,7 +393,7 @@ Java_sun_font_CStrike_getFontMetrics
 {
     jobject metrics = NULL;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     AWT_FONT_CLEANUP_SETUP;
 
     AWTFont *awtfont = ((AWTStrike *)jlong_to_ptr(awtStrikePtr))->fAWTFont;
@@ -436,7 +436,7 @@ JNF_COCOA_ENTER(env);
 
 cleanup:
     AWT_FONT_CLEANUP_FINISH;
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return metrics;
 }
@@ -450,9 +450,9 @@ extern void AccelGlyphCache_RemoveAllInfos(GlyphInfo* glyph);
 JNIEXPORT void JNICALL Java_sun_font_CStrikeDisposer_removeGlyphInfoFromCache
 (JNIEnv *env, jclass cls, jlong glyphInfo)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     AccelGlyphCache_RemoveAllCellInfos((GlyphInfo*)jlong_to_ptr(glyphInfo));
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/CCharToGlyphMapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/CCharToGlyphMapper.m
@@ -23,6 +23,8 @@
  * questions.
  */
 
+#import "JNIUtilities.h"
+
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "AWTFont.h"
@@ -41,12 +43,12 @@ Java_sun_font_CCharToGlyphMapper_countGlyphs
 {
     jint numGlyphs = 0;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTFont *awtFont = (AWTFont *)jlong_to_ptr(awtFontPtr);
     numGlyphs = [awtFont->fFont numberOfGlyphs];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return numGlyphs;
 }
@@ -90,7 +92,7 @@ Java_sun_font_CCharToGlyphMapper_nativeCharsToGlyphs
     (JNIEnv *env, jclass clazz,
      jlong awtFontPtr, jint count, jcharArray unicodes, jintArray glyphs)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     AWTFont *awtFont = (AWTFont *)jlong_to_ptr(awtFontPtr);
 
@@ -111,5 +113,5 @@ JNF_COCOA_ENTER(env);
                                               unicodesAsChars, JNI_ABORT);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLGraphicsConfig.m
@@ -28,6 +28,7 @@
 #import "CGLGraphicsConfig.h"
 #import "CGLSurfaceData.h"
 #import "ThreadUtilities.h"
+#import "JNIUtilities.h"
 
 #import <stdlib.h>
 #import <string.h>
@@ -120,7 +121,7 @@ Java_sun_java2d_opengl_CGLGraphicsConfig_getCGLConfigInfo
     (JNIEnv *env, jclass cglgc)
 {
     __block jlong ret = 0L;
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
@@ -288,7 +289,7 @@ Java_sun_java2d_opengl_CGLGraphicsConfig_getCGLConfigInfo
         ret = ptr_to_jlong(cglinfo);
         [pool drain];
     }];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
     return ret;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.m
@@ -170,7 +170,7 @@ Java_sun_java2d_opengl_CGLLayer_nativeCreateLayer
 {
     __block CGLLayer *layer = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     JNFWeakJObjectWrapper *javaLayer = [JNFWeakJObjectWrapper wrapperWithJObject:obj withEnv:env];
 
@@ -180,7 +180,7 @@ JNF_COCOA_ENTER(env);
             layer = [[CGLLayer alloc] initWithJavaLayer: javaLayer];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(layer);
 }
@@ -217,7 +217,7 @@ JNIEXPORT void JNICALL
 Java_sun_java2d_opengl_CGLLayer_nativeSetScale
 (JNIEnv *env, jclass cls, jlong layerPtr, jdouble scale)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
     CGLLayer *layer = jlong_to_ptr(layerPtr);
     // We always call all setXX methods asynchronously, exception is only in
     // this method where we need to change native texture size and layer's scale
@@ -226,5 +226,5 @@ Java_sun_java2d_opengl_CGLLayer_nativeSetScale
     [ThreadUtilities performOnMainThreadWaiting:[NSThread isMainThread] block:^(){
         layer.contentsScale = scale;
     }];
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLSurfaceData.m
@@ -27,7 +27,7 @@
 
 #import "sun_java2d_opengl_CGLSurfaceData.h"
 
-#import "jni_util.h"
+#import "JNIUtilities.h"
 #import "OGLRenderQueue.h"
 #import "CGLGraphicsConfig.h"
 #import "CGLSurfaceData.h"
@@ -62,9 +62,9 @@ OGLSD_UnlockFocus(OGLContext *oglc, OGLSDOps *dstOps)
 
     NSOpenGLView *nsView = cglsdo->peerData;
     if (nsView != NULL) {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         [nsView unlockFocus];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     }
 }
 #endif
@@ -85,7 +85,7 @@ CGLSD_MakeCurrentToScratch(JNIEnv *env, OGLContext *oglc)
         return JNI_FALSE;
     }
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CGLCtxInfo *ctxinfo = (CGLCtxInfo *)oglc->ctxInfo;
 #if USE_NSVIEW_FOR_SCRATCH
@@ -99,7 +99,7 @@ JNF_COCOA_ENTER(env);
             currentVirtualScreen: [ctxinfo->context currentVirtualScreen]];
 #endif
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return JNI_TRUE;
 }
@@ -113,7 +113,7 @@ OGLSD_DestroyOGLSurface(JNIEnv *env, OGLSDOps *oglsdo)
 {
     J2dTraceLn(J2D_TRACE_INFO, "OGLSD_DestroyOGLSurface");
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CGLSDOps *cglsdo = (CGLSDOps *)oglsdo->privOps;
     if (oglsdo->drawableType == OGLSD_WINDOW) {
@@ -126,7 +126,7 @@ JNF_COCOA_ENTER(env);
 
     oglsdo->drawableType = OGLSD_UNDEFINED;
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /**
@@ -154,7 +154,7 @@ OGLSD_SetScratchSurface(JNIEnv *env, jlong pConfigInfo)
 
     CGLCtxInfo *ctxinfo = (CGLCtxInfo *)oglc->ctxInfo;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     // avoid changing the context's target view whenever possible, since
     // calling setView causes flickering; as long as our context is current
@@ -181,7 +181,7 @@ JNF_COCOA_ENTER(env);
         j2d_glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return oglc;
 }
@@ -235,7 +235,7 @@ OGLSD_MakeOGLContextCurrent(JNIEnv *env, OGLSDOps *srcOps, OGLSDOps *dstOps)
         return oglc;
     }
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CGLSDOps *cglsdo = (CGLSDOps *)dstOps->privOps;
     NSView *nsView = (NSView *)cglsdo->peerData;
@@ -252,7 +252,7 @@ JNF_COCOA_ENTER(env);
         j2d_glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return oglc;
 }
@@ -284,13 +284,13 @@ OGLSD_InitOGLWindow(JNIEnv *env, OGLSDOps *oglsdo)
         return JNI_FALSE;
     }
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     NSRect surfaceBounds = [v bounds];
     oglsdo->drawableType = OGLSD_WINDOW;
     oglsdo->isOpaque = JNI_TRUE;
     oglsdo->width = surfaceBounds.size.width;
     oglsdo->height = surfaceBounds.size.height;
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     J2dTraceLn2(J2D_TRACE_VERBOSE, "  created window: w=%d h=%d", oglsdo->width, oglsdo->height);
 
@@ -302,9 +302,9 @@ OGLSD_SwapBuffers(JNIEnv *env, jlong pPeerData)
 {
     J2dTraceLn(J2D_TRACE_INFO, "OGLSD_SwapBuffers");
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     [[NSOpenGLContext currentContext] flushBuffer];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 void

--- a/src/java.desktop/macosx/native/libosx/CFileManager.m
+++ b/src/java.desktop/macosx/native/libosx/CFileManager.m
@@ -25,6 +25,8 @@
 
 #import "com_apple_eio_FileManager.h"
 
+#import "JNIUtilities.h"
+
 #import <Cocoa/Cocoa.h>
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
@@ -39,13 +41,13 @@
 JNIEXPORT void JNICALL Java_com_apple_eio_FileManager__1setFileTypeAndCreator
 (JNIEnv *env, jclass clz, jstring javaFilename, jint type, jint creator)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         NSString *filename = JNFNormalizedNSStringForPath(env, javaFilename);
         NSDictionary *attr = [NSDictionary dictionaryWithObjectsAndKeys:
                                                         [NSNumber numberWithInt:type], NSFileHFSTypeCode,
                                                         [NSNumber numberWithInt:creator], NSFileHFSCreatorCode, nil];
     [[NSFileManager defaultManager] changeFileAttributes:attr atPath:filename];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -56,11 +58,11 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eio_FileManager__1setFileType
 (JNIEnv *env, jclass ckz, jstring javaFilename, jint type)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         NSString *filename = JNFNormalizedNSStringForPath(env, javaFilename);
         NSDictionary *attr = [NSDictionary dictionaryWithObject:[NSNumber numberWithInt:type] forKey:NSFileHFSTypeCode];
     [[NSFileManager defaultManager] changeFileAttributes:attr atPath:filename];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -71,11 +73,11 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eio_FileManager__1setFileCreator
 (JNIEnv *env, jclass clz, jstring javaFilename, jint creator)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         NSString *filename = JNFNormalizedNSStringForPath(env, javaFilename);
         NSDictionary *attr = [NSDictionary dictionaryWithObject:[NSNumber numberWithInt:creator] forKey:NSFileHFSCreatorCode];
     [[NSFileManager defaultManager] changeFileAttributes:attr atPath:filename];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -87,12 +89,12 @@ JNIEXPORT jint JNICALL Java_com_apple_eio_FileManager__1getFileType
 (JNIEnv *env, jclass clz, jstring javaFilename)
 {
     jint type = 0;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         NSString *filename = JNFNormalizedNSStringForPath(env, javaFilename);
     NSDictionary *attributes = [[NSFileManager defaultManager] fileAttributesAtPath:filename traverseLink:YES];
     NSNumber *val = [attributes objectForKey:NSFileHFSTypeCode];
     type = [val intValue];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return type;
 }
 
@@ -105,12 +107,12 @@ JNIEXPORT jint JNICALL Java_com_apple_eio_FileManager__1getFileCreator
   (JNIEnv *env, jclass clz, jstring javaFilename)
 {
     jint creator = 0;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
         NSString *filename = JNFNormalizedNSStringForPath(env, javaFilename);
     NSDictionary *attributes = [[NSFileManager defaultManager] fileAttributesAtPath:filename traverseLink:YES];
     NSNumber *val = [attributes objectForKey:NSFileHFSCreatorCode];
     creator = [val intValue];
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return creator;
 }
 
@@ -123,7 +125,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_eio_FileManager__1findFolder__SIZ
 (JNIEnv *env, jclass clz, jshort domain, jint folderType, jboolean createIfNeeded)
 {
     jstring filename = nil;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     FSRef foundRef;
     createIfNeeded = createIfNeeded || (folderType == kTemporaryFolderType) || (folderType == kChewableItemsFolderType);
@@ -135,7 +137,7 @@ JNF_COCOA_ENTER(env);
         }
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return filename;
 }
 
@@ -148,7 +150,7 @@ JNF_COCOA_EXIT(env);
 JNIEXPORT void JNICALL Java_com_apple_eio_FileManager__1openURL
 (JNIEnv *env, jclass clz, jstring urlString)
 {
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSURL *url = [NSURL URLWithString:JNFNormalizedNSStringForPath(env, urlString)];
 
@@ -157,7 +159,7 @@ JNF_COCOA_ENTER(env);
         [[NSWorkspace sharedWorkspace] openURL:url];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 
@@ -170,7 +172,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_eio_FileManager_getNativeResourceFromBu
 (JNIEnv *env, jclass clz, jstring javaResourceName, jstring javaSubDirName, jstring javaTypeName)
 {
     jstring filename = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *resourceName = JNFNormalizedNSStringForPath(env, javaResourceName);
         NSString *subDirectory = JNFNormalizedNSStringForPath(env, javaSubDirName);
@@ -182,7 +184,7 @@ JNF_COCOA_ENTER(env);
 
     filename = JNFNormalizedJavaStringForPath(env, path);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return filename;
 }
 
@@ -196,12 +198,12 @@ JNIEXPORT jstring JNICALL Java_com_apple_eio_FileManager_getNativePathToApplicat
 (JNIEnv *env, jclass clazz)
 {
         jstring filename = nil;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
         NSBundle *mainBundle = [NSBundle mainBundle];
         filename = JNFNormalizedJavaStringForPath(env, [mainBundle bundlePath]);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
         return filename;
 }
 
@@ -216,7 +218,7 @@ JNIEXPORT jboolean JNICALL Java_com_apple_eio_FileManager__1moveToTrash
 (JNIEnv *env, jclass clz, jstring fileName)
 {
     __block BOOL returnValue = NO;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString * path = JNFNormalizedNSStringForPath(env, fileName);
     NSURL *url = [NSURL fileURLWithPath:path];
@@ -227,7 +229,7 @@ JNF_COCOA_ENTER(env);
                                                                 error:nil];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
         return returnValue ? JNI_TRUE: JNI_FALSE;
 }
@@ -242,14 +244,14 @@ JNIEXPORT jboolean JNICALL Java_com_apple_eio_FileManager__1revealInFinder
 (JNIEnv *env, jclass clz, jstring url)
 {
         __block jboolean returnValue = JNI_FALSE;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NSString *path = JNFNormalizedNSStringForPath(env, url);
     [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
         returnValue = [[NSWorkspace sharedWorkspace] selectFile:path inFileViewerRootedAtPath:@""];
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
         return returnValue;
 }

--- a/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
@@ -206,4 +206,35 @@
        return y; \
     };
 
+/* Create a pool and initiate a try block to catch any exception */
+#define JNI_COCOA_ENTER(env) \
+ NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
+ @try {
+
+/* Don't allow NSExceptions to escape to Java.
+ * If there is a Java exception that has been thrown that should escape.
+ * And ensure we drain the auto-release pool.
+ */
+#define JNI_COCOA_EXIT(env) \
+ } \
+ @catch (NSException *e) { \
+     NSLog(@"%@", [e callStackSymbols]); \
+ } \
+ @finally { \
+    [pool drain]; \
+ };
+
+/* Same as above but adds a clean up action.
+ * Requires that whatever is being cleaned up is in scope.
+ */
+#define JNI_COCOA_EXIT_WITH_ACTION(env, action) \
+ } \
+ @catch (NSException *e) { \
+     { action; }; \
+     NSLog(@"%@", [e callStackSymbols]); \
+ } \
+ @finally { \
+    [pool drain]; \
+ };
+
 #endif /* __JNIUTILITIES_H */

--- a/src/java.desktop/macosx/native/libosxui/AquaFileView.m
+++ b/src/java.desktop/macosx/native/libosxui/AquaFileView.m
@@ -24,7 +24,7 @@
  */
 
 
-#include <jni_util.h>
+#include <JNIUtilities.h>
 
 #import "com_apple_laf_AquaFileView.h"
 
@@ -42,11 +42,11 @@
 (JNIEnv *env, jclass clazz)
 {
     jstring returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     returnValue = JNFNSToJavaString(env, getRunningJavaBundle());
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }*/
 
@@ -59,11 +59,11 @@ JNIEXPORT jstring JNICALL Java_com_apple_laf_AquaFileView_getNativePathToSharedJ
 (JNIEnv *env, jclass clazz)
 {
     jstring returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     returnValue = JNFNSToJavaString(env, [[NSBundle bundleWithIdentifier:@"com.apple.JavaVM"] bundlePath]);
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -76,7 +76,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_laf_AquaFileView_getNativeMachineName
 (JNIEnv *env, jclass clazz)
 {
     jstring returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     CFStringRef machineName = CSCopyMachineName();
     returnValue = JNFNSToJavaString(env, (NSString*)machineName);
@@ -85,7 +85,7 @@ JNF_COCOA_ENTER(env);
         CFRelease(machineName);
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -98,7 +98,7 @@ JNIEXPORT jint JNICALL Java_com_apple_laf_AquaFileView_getNativeLSInfo
 (JNIEnv *env, jclass clazz, jbyteArray absolutePath, jboolean isDir)
 {
     jint returnValue = com_apple_laf_AquaFileView_UNINITALIZED_LS_INFO;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jbyte *byteArray = (*env)->GetByteArrayElements(env, absolutePath, NULL);
     CHECK_NULL_RETURN(byteArray, returnValue);
@@ -126,7 +126,7 @@ JNF_COCOA_ENTER(env);
         }
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -139,7 +139,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_laf_AquaFileView_getNativeDisplayName
 (JNIEnv *env, jclass clazz, jbyteArray absolutePath, jboolean isDir)
 {
     jstring returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     jbyte *byteArray = (*env)->GetByteArrayElements(env, absolutePath, NULL);
     CHECK_NULL_RETURN(byteArray, returnValue);
@@ -178,7 +178,7 @@ JNF_COCOA_ENTER(env);
         }
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }
 
@@ -191,7 +191,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_laf_AquaFileView_getNativePathForResolv
 (JNIEnv *env, jclass clazz, jbyteArray pathToAlias, jboolean isDir)
 {
     jstring returnValue = NULL;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     UInt8 pathCString[MAXPATHLEN + 1];
     size_t maxPathLen = sizeof(pathCString) - 1;
@@ -224,6 +224,6 @@ JNF_COCOA_ENTER(env);
         }
     }
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return returnValue;
 }

--- a/src/java.desktop/macosx/native/libosxui/AquaNativeResources.m
+++ b/src/java.desktop/macosx/native/libosxui/AquaNativeResources.m
@@ -39,10 +39,10 @@ JNIEXPORT jlong JNICALL Java_com_apple_laf_AquaNativeResources_getWindowBackgrou
     // TODO(cpc): this code is currently disabled at the Java level
 #if 0
     NSColor* color = nil;
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     color = [NSColor lightGrayColor];//[AWTColor getMagicBackgroundColor];
     if (color) CFRetain(color); // GC
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
     return ptr_to_jlong(color);
 #else
     return 0L;

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
@@ -105,13 +105,13 @@ static jint ns2awtMouseButton(NSInteger mouseButton) {
     }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     //NSLog(@"menuWillOpen %@", [menu title]);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_invokeOpenLater, sjc_ScreenMenu, "invokeOpenLater", "()V");
     (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeOpenLater); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
 }
 
@@ -125,13 +125,13 @@ JNF_COCOA_EXIT(env);
     }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     //NSLog(@"menuDidClose %@", [menu title]);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_invokeMenuClosing, sjc_ScreenMenu, "invokeMenuClosing", "()V");
     (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeMenuClosing); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 
@@ -145,7 +145,7 @@ JNF_COCOA_EXIT(env);
     }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     // Send that to Java so we can test which item was hit.
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_updateSelectedItem, sjc_ScreenMenu, "handleItemTargeted", "(IIIII)V");
@@ -153,7 +153,7 @@ JNF_COCOA_ENTER(env);
                     NSMinY(rect), NSMinX(rect), NSMaxY(rect), NSMaxX(rect)); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 
@@ -191,13 +191,13 @@ JNF_COCOA_EXIT(env);
 
     // Call the mouse event handler, which will generate Java mouse events.
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_handleMouseEvent, sjc_ScreenMenu, "handleMouseEvent", "(IIIIJ)V");
     (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_handleMouseEvent,
              javaKind, javaX, javaY, javaModifiers, javaWhen); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }
 
 @end
@@ -213,7 +213,7 @@ JNIEXPORT jlong JNICALL Java_com_apple_laf_ScreenMenu_addMenuListeners
 {
     NativeToJavaDelegate *delegate = nil;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     JNFJObjectWrapper *wrapper = [JNFJObjectWrapper wrapperWithJObject:listener withEnv:env];
     NSMenu *menu = jlong_to_ptr(nativeMenu);
@@ -229,7 +229,7 @@ JNF_COCOA_ENTER(env);
         }
     }];
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 
     return ptr_to_jlong(delegate);
 }
@@ -244,7 +244,7 @@ JNIEXPORT void JNICALL Java_com_apple_laf_ScreenMenu_removeMenuListeners
 {
     if (fModelPtr == 0L) return;
 
-JNF_COCOA_ENTER(env);
+JNI_COCOA_ENTER(env);
 
     NativeToJavaDelegate *delegate = (NativeToJavaDelegate *)jlong_to_ptr(fModelPtr);
 
@@ -258,5 +258,5 @@ JNF_COCOA_ENTER(env);
 
     CFRelease(delegate); // GC
 
-JNF_COCOA_EXIT(env);
+JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
Part 5/8 of JNF removal patches, applies almost cleanly, only slight context code difference in one place

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259651](https://bugs.openjdk.java.net/browse/JDK-8259651): [macOS] Replace JNF_COCOA_ENTER/EXIT macros


### Reviewers
 * serb - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/11.diff">https://git.openjdk.java.net/jdk15u-dev/pull/11.diff</a>

</details>
