### PR TITLE
8259869: [macOS] Remove desktop module dependencies on JNF Reference APIs

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -118,7 +118,7 @@ static BOOL shouldUsePressAndHold() {
     {
         JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
-        JNFDeleteGlobalRef(env, fInputMethodLOCKABLE);
+        (*env)->DeleteGlobalRef(env, fInputMethodLOCKABLE);
         fInputMethodLOCKABLE = NULL;
     }
 
@@ -1360,14 +1360,10 @@ static jclass jc_CInputMethod = NULL;
 
     // Get rid of the old one
     if (fInputMethodLOCKABLE) {
-        JNFDeleteGlobalRef(env, fInputMethodLOCKABLE);
+        (*env)->DeleteGlobalRef(env, fInputMethodLOCKABLE);
     }
 
-    // Save a global ref to the new input method.
-    if (inputMethod != NULL)
-        fInputMethodLOCKABLE = JNFNewGlobalRef(env, inputMethod);
-    else
-        fInputMethodLOCKABLE = NULL;
+    fInputMethodLOCKABLE = inputMethod; // input method arg must be a GlobalRef
 
     NSTextInputContext *curContxt = [NSTextInputContext currentInputContext];
     kbdLayout = curContxt.selectedKeyboardInputSource;
@@ -1409,6 +1405,7 @@ Java_sun_lwawt_macosx_CPlatformView_nativeCreateView
 
     NSRect rect = NSMakeRect(originX, originY, width, height);
     jobject cPlatformView = (*env)->NewWeakGlobalRef(env, obj);
+    CHECK_EXCEPTION();
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.h
@@ -32,11 +32,10 @@
 #import "LWCToolkit.h"
 
 @class AWTView;
-@class JNFWeakJObjectWrapper;
 
 @interface AWTWindow : NSObject <NSWindowDelegate> {
 @private
-    JNFWeakJObjectWrapper *javaPlatformWindow;
+    jobject javaPlatformWindow; /* This is a weak ref. Always copy to a local ref before using */
     CMenuBar *javaMenuBar;
     NSSize javaMinSize;
     NSSize javaMaxSize;
@@ -53,7 +52,7 @@
 // An instance of either AWTWindow_Normal or AWTWindow_Panel
 @property (nonatomic, retain) NSWindow *nsWindow;
 
-@property (nonatomic, retain) JNFWeakJObjectWrapper *javaPlatformWindow;
+@property (nonatomic) jobject javaPlatformWindow;
 @property (nonatomic, retain) CMenuBar *javaMenuBar;
 @property (nonatomic, retain) AWTWindow *ownerWindow;
 @property (nonatomic) NSSize javaMinSize;
@@ -65,7 +64,7 @@
 @property (nonatomic) BOOL isMinimizing;
 @property (nonatomic) BOOL keyNotificationRecd;
 
-- (id) initWithPlatformWindow:(JNFWeakJObjectWrapper *)javaPlatformWindow
+- (id) initWithPlatformWindow:(jobject)javaPlatformWindow
                   ownerWindow:owner
                     styleBits:(jint)styleBits
                     frameRect:(NSRect)frameRect

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -116,7 +116,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
     AWT_ASSERT_APPKIT_THREAD;
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [((AWTWindow *)self.delegate).javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, ((AWTWindow *)self.delegate).javaPlatformWindow);
     if (platformWindow != NULL) {
         // extract the target AWT Window object out of the CPlatformWindow
         GET_CPLATFORM_WINDOW_CLASS();
@@ -281,7 +281,7 @@ AWT_NS_WINDOW_IMPLEMENTATION
     }
 }
 
-- (id) initWithPlatformWindow:(JNFWeakJObjectWrapper *)platformWindow
+- (id) initWithPlatformWindow:(jobject)platformWindow
                   ownerWindow:owner
                     styleBits:(jint)bits
                     frameRect:(NSRect)rect
@@ -482,7 +482,7 @@ AWT_ASSERT_APPKIT_THREAD;
 AWT_ASSERT_APPKIT_THREAD;
 
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-    [self.javaPlatformWindow setJObject:nil withEnv:env];
+    (*env)->DeleteWeakGlobalRef(env, self.javaPlatformWindow);
     self.javaPlatformWindow = nil;
     self.nsWindow = nil;
     self.ownerWindow = nil;
@@ -494,7 +494,7 @@ AWT_ASSERT_APPKIT_THREAD;
     BOOL isBlocked = NO;
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS_RETURN(isBlocked);
         DECLARE_METHOD_RETURN(jm_isBlocked, jc_CPlatformWindow, "isBlocked", "()Z", isBlocked);
@@ -511,7 +511,7 @@ AWT_ASSERT_APPKIT_THREAD;
     BOOL isSimpleWindowOwnedByEmbeddedFrame = NO;
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS_RETURN(NO);
         DECLARE_METHOD_RETURN(jm_isBlocked, jc_CPlatformWindow, "isSimpleWindowOwnedByEmbeddedFrame", "()Z", NO);
@@ -532,7 +532,7 @@ AWT_ASSERT_APPKIT_THREAD;
         [AWTToolkit eventCountPlusPlus];
 
         JNIEnv *env = [ThreadUtilities getJNIEnv];
-        jobject platformWindow = [awtWindow.javaPlatformWindow jObjectWithEnv:env];
+        jobject platformWindow = (*env)->NewLocalRef(env, awtWindow.javaPlatformWindow);
         if (platformWindow != NULL) {
             GET_CPLATFORM_WINDOW_CLASS_RETURN(isVisible);
             DECLARE_METHOD_RETURN(jm_isVisible, jc_CPlatformWindow, "isVisible", "()Z", isVisible)
@@ -603,7 +603,7 @@ AWT_ASSERT_APPKIT_THREAD;
         [AWTToolkit eventCountPlusPlus];
 
         JNIEnv *env = [ThreadUtilities getJNIEnv];
-        jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+        jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
         if (platformWindow != NULL) {
             GET_CPLATFORM_WINDOW_CLASS_RETURN(NO);
             DECLARE_METHOD_RETURN(jm_checkBlockingAndOrder, jc_CPlatformWindow, "checkBlockingAndOrder", "()Z", NO);
@@ -632,7 +632,7 @@ AWT_ASSERT_APPKIT_THREAD;
     // the bounds of the window to avoid the Dock or remain on screen.
     [AWTToolkit eventCountPlusPlus];
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow == NULL) {
         // TODO: create generic AWT assert
     }
@@ -710,7 +710,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
     [AWTToolkit eventCountPlusPlus];
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS();
         DECLARE_METHOD(jm_deliverIconify, jc_CPlatformWindow, "deliverIconify", "(Z)V");
@@ -726,7 +726,7 @@ AWT_ASSERT_APPKIT_THREAD;
     self.isMinimizing = YES;
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS();
         DECLARE_METHOD(jm_windowWillMiniaturize, jc_CPlatformWindow, "windowWillMiniaturize", "()V");
@@ -757,9 +757,9 @@ AWT_ASSERT_APPKIT_THREAD;
 - (void) _deliverWindowFocusEvent:(BOOL)focused oppositeWindow:(AWTWindow *)opposite {
 //AWT_ASSERT_APPKIT_THREAD;
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
-        jobject oppositeWindow = [opposite.javaPlatformWindow jObjectWithEnv:env];
+        jobject oppositeWindow = (*env)->NewLocalRef(env, opposite.javaPlatformWindow);
         GET_CPLATFORM_WINDOW_CLASS();
         DECLARE_METHOD(jm_deliverWindowFocusEvent, jc_CPlatformWindow, "deliverWindowFocusEvent", "(ZLsun/lwawt/macosx/CPlatformWindow;)V");
         (*env)->CallVoidMethod(env, platformWindow, jm_deliverWindowFocusEvent, (jboolean)focused, oppositeWindow);
@@ -788,7 +788,7 @@ AWT_ASSERT_APPKIT_THREAD;
     }
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS();
         DECLARE_METHOD(jm_windowDidBecomeMain, jc_CPlatformWindow, "windowDidBecomeMain", "()V");
@@ -904,7 +904,7 @@ AWT_ASSERT_APPKIT_THREAD;
 AWT_ASSERT_APPKIT_THREAD;
     [AWTToolkit eventCountPlusPlus];
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS_RETURN(NO);
         DECLARE_METHOD_RETURN(jm_deliverWindowClosingEvent, jc_CPlatformWindow, "deliverWindowClosingEvent", "()V", NO);
@@ -922,7 +922,7 @@ AWT_ASSERT_APPKIT_THREAD;
                            "handleFullScreenEventFromNative", "(Ljava/awt/Window;I)V");
     GET_CPLATFORM_WINDOW_CLASS();
     DECLARE_FIELD(jf_target, jc_CPlatformWindow, "target", "Ljava/awt/Window;");
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         jobject awtWindow = (*env)->GetObjectField(env, platformWindow, jf_target);
         if (awtWindow != NULL) {
@@ -939,7 +939,7 @@ AWT_ASSERT_APPKIT_THREAD;
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CPLATFORM_WINDOW_CLASS();
     DECLARE_METHOD(jm_windowWillEnterFullScreen, jc_CPlatformWindow, "windowWillEnterFullScreen", "()V");
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         (*env)->CallVoidMethod(env, platformWindow, jm_windowWillEnterFullScreen);
         CHECK_EXCEPTION();
@@ -952,7 +952,7 @@ AWT_ASSERT_APPKIT_THREAD;
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CPLATFORM_WINDOW_CLASS();
     DECLARE_METHOD(jm_windowDidEnterFullScreen, jc_CPlatformWindow, "windowDidEnterFullScreen", "()V");
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         (*env)->CallVoidMethod(env, platformWindow, jm_windowDidEnterFullScreen);
         CHECK_EXCEPTION();
@@ -971,7 +971,7 @@ AWT_ASSERT_APPKIT_THREAD;
         jm_windowWillExitFullScreen = (*env)->GetMethodID(env, jc_CPlatformWindow, "windowWillExitFullScreen", "()V");
     }
     CHECK_NULL(jm_windowWillExitFullScreen);
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         (*env)->CallVoidMethod(env, platformWindow, jm_windowWillExitFullScreen);
         CHECK_EXCEPTION();
@@ -982,7 +982,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
     if (platformWindow != NULL) {
         GET_CPLATFORM_WINDOW_CLASS();
         DECLARE_METHOD(jm_windowDidExitFullScreen, jc_CPlatformWindow, "windowDidExitFullScreen", "()V");
@@ -1001,7 +1001,7 @@ AWT_ASSERT_APPKIT_THREAD;
                 // in front of its nearest parent.
                 if (self.ownerWindow != nil) {
                     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-                    jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+                    jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
                     if (platformWindow != NULL) {
                         GET_CPLATFORM_WINDOW_CLASS();
                         DECLARE_METHOD(jm_orderAboveSiblings, jc_CPlatformWindow, "orderAboveSiblings", "()V");
@@ -1020,7 +1020,7 @@ AWT_ASSERT_APPKIT_THREAD;
             // Check if the click happened in the non-client area (title bar)
             if (p.y >= (frame.origin.y + contentRect.size.height)) {
                 JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-                jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
+                jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
                 if (platformWindow != NULL) {
                     // Currently, no need to deliver the whole NSEvent.
                     GET_CPLATFORM_WINDOW_CLASS();
@@ -1103,7 +1103,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeCreateNSWind
 
 JNI_COCOA_ENTER(env);
 
-    JNFWeakJObjectWrapper *platformWindow = [JNFWeakJObjectWrapper wrapperWithJObject:obj withEnv:env];
+    jobject platformWindow = (*env)->NewWeakGlobalRef(env, obj);
     NSView *contentView = OBJC(contentViewPtr);
     NSRect frameRect = NSMakeRect(x, y, w, h);
     AWTWindow *owner = [OBJC(ownerPtr) delegate];
@@ -1544,7 +1544,7 @@ JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeGetTopmostPlatformWindowUnde
     [ThreadUtilities performOnMainThreadWaiting:YES block:^{
         AWTWindow *awtWindow = [AWTWindow getTopmostWindowUnderMouse];
         if (awtWindow != nil) {
-            topmostWindowUnderMouse = [awtWindow.javaPlatformWindow jObject];
+            topmostWindowUnderMouse = awtWindow.javaPlatformWindow;
         }
     }];
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -66,9 +66,9 @@
     @synchronized(self) {
         if (owner != NULL) {
             if (self.clipboardOwner != NULL) {
-                JNFDeleteGlobalRef(env, self.clipboardOwner);
+                (*env)->DeleteGlobalRef(env, self.clipboardOwner);
             }
-            self.clipboardOwner = JNFNewGlobalRef(env, owner);
+            self.clipboardOwner = (*env)->NewGlobalRef(env, owner);
         }
     }
     [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
@@ -101,7 +101,7 @@
             if (self.clipboardOwner) {
                 (*env)->CallVoidMethod(env, self.clipboardOwner, jm_lostOwnership); // AWT_THREADING Safe (event)
                 CHECK_EXCEPTION();
-                JNFDeleteGlobalRef(env, self.clipboardOwner);
+                (*env)->DeleteGlobalRef(env, self.clipboardOwner);
                 self.clipboardOwner = NULL;
             }
         }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
@@ -169,32 +169,32 @@ static BOOL                sNeedsEnter;
 
     // Clean up JNI refs
     if (fComponent != NULL) {
-        JNFDeleteGlobalRef(env, fComponent);
+        (*env)->DeleteGlobalRef(env, fComponent);
         fComponent = NULL;
     }
 
     if (fDragSourceContextPeer != NULL) {
-        JNFDeleteGlobalRef(env, fDragSourceContextPeer);
+        (*env)->DeleteGlobalRef(env, fDragSourceContextPeer);
         fDragSourceContextPeer = NULL;
     }
 
     if (fTransferable != NULL) {
-        JNFDeleteGlobalRef(env, fTransferable);
+        (*env)->DeleteGlobalRef(env, fTransferable);
         fTransferable = NULL;
     }
 
     if (fTriggerEvent != NULL) {
-        JNFDeleteGlobalRef(env, fTriggerEvent);
+        (*env)->DeleteGlobalRef(env, fTriggerEvent);
         fTriggerEvent = NULL;
     }
 
     if (fFormats != NULL) {
-        JNFDeleteGlobalRef(env, fFormats);
+        (*env)->DeleteGlobalRef(env, fFormats);
         fFormats = NULL;
     }
 
     if (fFormatMap != NULL) {
-        JNFDeleteGlobalRef(env, fFormatMap);
+        (*env)->DeleteGlobalRef(env, fFormatMap);
         fFormatMap = NULL;
     }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSourceContextPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSourceContextPeer.m
@@ -50,12 +50,12 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CDragSourceContextPeer_createNativ
 JNI_COCOA_ENTER(env);
 
     // Global references are disposed when the DragSource is removed
-    jobject gComponent = JNFNewGlobalRef(env, jcomponent);
-    jobject gDragSourceContextPeer = JNFNewGlobalRef(env, jthis);
-    jobject gTransferable = JNFNewGlobalRef(env, jtransferable);
-    jobject gTriggerEvent = JNFNewGlobalRef(env, jtrigger);
-    jlongArray gFormats = JNFNewGlobalRef(env, jformats);
-    jobject gFormatMap = JNFNewGlobalRef(env, jformatmap);
+    jobject gComponent = (*env)->NewGlobalRef(env, jcomponent);
+    jobject gDragSourceContextPeer = (*env)->NewGlobalRef(env, jthis);
+    jobject gTransferable = (*env)->NewGlobalRef(env, jtransferable);
+    jobject gTriggerEvent = (*env)->NewGlobalRef(env, jtrigger);
+    jlongArray gFormats = (*env)->NewGlobalRef(env, jformats);
+    jobject gFormatMap = (*env)->NewGlobalRef(env, jformatmap);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         dragSource = [[CDragSource alloc] init:gDragSourceContextPeer

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
@@ -84,8 +84,8 @@ extern jclass jc_CDropTargetContextPeer;
 
     if (control != nil) {
         JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-        fComponent = JNFNewGlobalRef(env, jcomponent);
-        fDropTarget = JNFNewGlobalRef(env, jdropTarget);
+        fComponent = (*env)->NewGlobalRef(env, jcomponent);
+        fDropTarget = (*env)->NewGlobalRef(env, jdropTarget);
 
         fView = [((AWTView *) control) retain];
         [fView setDropTarget:self];
@@ -148,7 +148,7 @@ extern jclass jc_CDropTargetContextPeer;
 
     if (sDraggingFormats != NULL) {
         JNIEnv *env = [ThreadUtilities getJNIEnv];
-        JNFDeleteGlobalRef(env, sDraggingFormats);
+        (*env)->DeleteGlobalRef(env, sDraggingFormats);
         sDraggingFormats = NULL;
     }
 
@@ -165,15 +165,15 @@ extern jclass jc_CDropTargetContextPeer;
 
     // Clean up JNI refs
     if (fComponent != NULL) {
-        JNFDeleteGlobalRef(env, fComponent);
+        (*env)->DeleteGlobalRef(env, fComponent);
         fComponent = NULL;
     }
     if (fDropTarget != NULL) {
-        JNFDeleteGlobalRef(env, fDropTarget);
+        (*env)->DeleteGlobalRef(env, fDropTarget);
         fDropTarget = NULL;
     }
     if (fDropTargetContextPeer != NULL) {
-        JNFDeleteGlobalRef(env, fDropTargetContextPeer);
+        (*env)->DeleteGlobalRef(env, fDropTargetContextPeer);
         fDropTargetContextPeer = NULL;
     }
 
@@ -239,7 +239,7 @@ extern jclass jc_CDropTargetContextPeer;
     if (formats == nil)
         return FALSE;
 
-    sDraggingFormats = (jlongArray) JNFNewGlobalRef(env, formats);
+    sDraggingFormats = (jlongArray) (*env)->NewGlobalRef(env, formats);
     (*env)->DeleteLocalRef(env, formats);
     if (sDraggingFormats == nil)
         return FALSE;
@@ -356,7 +356,7 @@ extern jclass jc_CDropTargetContextPeer;
     jbyteArray lbyteArray = (*env)->NewByteArray(env, dataLength);
     if (lbyteArray == nil)
         return nil;
-    jbyteArray gbyteArray = (jbyteArray) JNFNewGlobalRef(env, lbyteArray);
+    jbyteArray gbyteArray = (jbyteArray) (*env)->NewGlobalRef(env, lbyteArray);
     (*env)->DeleteLocalRef(env, lbyteArray);
     if (gbyteArray == nil)
         return nil;
@@ -459,7 +459,7 @@ extern jclass jc_CDropTargetContextPeer;
 
         // Delete any drop target context peer left over from a previous drag:
         if (fDropTargetContextPeer != NULL) {
-            JNFDeleteGlobalRef(env, fDropTargetContextPeer);
+            (*env)->DeleteGlobalRef(env, fDropTargetContextPeer);
             fDropTargetContextPeer = NULL;
         }
 
@@ -473,7 +473,7 @@ extern jclass jc_CDropTargetContextPeer;
             CHECK_EXCEPTION();
 
             if (dropTargetContextPeer != nil) {
-                fDropTargetContextPeer = JNFNewGlobalRef(env, dropTargetContextPeer);
+                fDropTargetContextPeer = (*env)->NewGlobalRef(env, dropTargetContextPeer);
                 (*env)->DeleteLocalRef(env, dropTargetContextPeer);
             }
         }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTargetContextPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTargetContextPeer.m
@@ -106,7 +106,7 @@ JNI_COCOA_ENTER(env);
         (*env)->CallVoidMethod(env, jthis, newDataMethod, jformat, jdropdata); // AWT_THREADING Safe (!appKit)
     } @catch (NSException *ex) {
         DLog2(@"[CDropTargetContextPeer startTransfer]: exception in newData() for %d.\n", (NSInteger) jdroptarget);
-        JNFDeleteGlobalRef(env, jdropdata);
+        (*env)->DeleteGlobalRef(env, jdropdata);
         TransferFailed(env, jthis, jdroptarget, (jlong) 0L, jformat);
         return result;
     }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CFileDialog.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CFileDialog.m
@@ -49,7 +49,7 @@ canChooseDirectories:(BOOL)inChooseDirectories
 {
   if (self = [super init]) {
         fHasFileFilter = inHasFilter;
-        fFileDialog = JNFNewGlobalRef(env, inDialog);
+        fFileDialog = (*env)->NewGlobalRef(env, inDialog);
         fDirectory = inPath;
         [fDirectory retain];
         fFile = inFile;
@@ -69,7 +69,7 @@ canChooseDirectories:(BOOL)inChooseDirectories
 -(void) disposer {
     if (fFileDialog != NULL) {
         JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-        JNFDeleteGlobalRef(env, fFileDialog);
+        (*env)->DeleteGlobalRef(env, fFileDialog);
         fFileDialog = NULL;
     }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
@@ -115,9 +115,9 @@ static void displaycb_handle
     [ThreadUtilities performOnMainThreadWaiting:NO block:^() {
 
         JNFPerformEnvBlock(JNFThreadDetachImmediately, ^(JNIEnv *env) {
-            JNFWeakJObjectWrapper *wrapper = (JNFWeakJObjectWrapper *)userInfo;
+            jobject cgeRef = (jobject)userInfo;
 
-            jobject graphicsEnv = [wrapper jObjectWithEnv:env];
+            jobject graphicsEnv = (*env)->NewLocalRef(env, cgeRef);
             if (graphicsEnv == NULL) return; // ref already GC'd
             DECLARE_CLASS(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
             DECLARE_METHOD(jm_displayReconfiguration,
@@ -143,15 +143,15 @@ Java_sun_awt_CGraphicsEnvironment_registerDisplayReconfiguration
 
 JNI_COCOA_ENTER(env);
 
-    JNFWeakJObjectWrapper *wrapper = [[JNFWeakJObjectWrapper wrapperWithJObject:this withEnv:env] retain];
+    jobject cgeRef = (*env)->NewWeakGlobalRef(env, this);
 
     /* Register the callback */
-    if (CGDisplayRegisterReconfigurationCallback(&displaycb_handle, wrapper) != kCGErrorSuccess) {
+    if (CGDisplayRegisterReconfigurationCallback(&displaycb_handle, cgeRef) != kCGErrorSuccess) {
         JNU_ThrowInternalError(env, "CGDisplayRegisterReconfigurationCallback() failed");
         return 0L;
     }
 
-    ret = ptr_to_jlong(wrapper);
+    ret = ptr_to_jlong(cgeRef);
 
 JNI_COCOA_EXIT(env);
 
@@ -169,17 +169,16 @@ Java_sun_awt_CGraphicsEnvironment_deregisterDisplayReconfiguration
 {
 JNI_COCOA_ENTER(env);
 
-    JNFWeakJObjectWrapper *wrapper = (JNFWeakJObjectWrapper *)jlong_to_ptr(p);
-    if (!wrapper) return;
+    jobject cgeRef = (jobject)jlong_to_ptr(p);
+    if (!cgeRef) return;
 
     /* Remove the registration */
-    if (CGDisplayRemoveReconfigurationCallback(&displaycb_handle, wrapper) != kCGErrorSuccess) {
+    if (CGDisplayRemoveReconfigurationCallback(&displaycb_handle, cgeRef) != kCGErrorSuccess) {
         JNU_ThrowInternalError(env, "CGDisplayRemoveReconfigurationCallback() failed, leaking the callback context!");
         return;
     }
 
-    [wrapper setJObject:NULL withEnv:env]; // more efficient to pre-clear
-    [wrapper release];
+    (*env)->DeleteWeakGlobalRef(env, cgeRef);
 
 JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuComponent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuComponent.m
@@ -43,7 +43,7 @@
 
 - (void)dealloc {
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-    JNFDeleteGlobalRef(env, fPeer);
+    (*env)->DeleteGlobalRef(env, fPeer);
     fPeer = NULL;
 
     [super dealloc];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPopupMenu.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPopupMenu.m
@@ -62,7 +62,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CPopupMenu_nativeCreatePopupMenu
 
 JNI_COCOA_ENTER(env);
 
-    jobject cPeerObjGlobal = JNFNewGlobalRef(env, peer);
+    jobject cPeerObjGlobal = (*env)->NewGlobalRef(env, peer);
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         aCPopupMenu = [[CPopupMenu alloc] initWithPeer:cPeerObjGlobal];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
@@ -75,7 +75,7 @@ static NSSize ScaledImageSizeForStatusBar(NSSize imageSize, BOOL autosize) {
 
 -(void) dealloc {
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
-    JNFDeleteGlobalRef(env, peer);
+    (*env)->DeleteGlobalRef(env, peer);
 
     [[NSStatusBar systemStatusBar] removeStatusItem: theItem];
 
@@ -335,7 +335,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CTrayIcon_nativeCreate
 
 JNI_COCOA_ENTER(env);
 
-    jobject thePeer = JNFNewGlobalRef(env, peer);
+    jobject thePeer = (*env)->NewGlobalRef(env, peer);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         trayIcon = [[AWTTrayIcon alloc] initWithPeer:thePeer];
     }];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
@@ -1452,7 +1452,7 @@ PRINT("ImageSD_dispose")
         qsdo->graphicsStateInfo.batchedLines = NULL;
     }
 
-    JNFDeleteGlobalRef(env, qsdo->javaGraphicsStatesObjects);
+    (*env)->DeleteGlobalRef(env, qsdo->javaGraphicsStatesObjects);
 
     if (qsdo->cgRef != NULL)
     {
@@ -1484,12 +1484,12 @@ PRINT("ImageSD_dispose")
     }
     if (isdo->array != NULL)
     {
-        JNFDeleteGlobalRef(env, isdo->array);
+        (*env)->DeleteGlobalRef(env, isdo->array);
         isdo->array = NULL;
     }
     if (isdo->icm != NULL)
     {
-        JNFDeleteGlobalRef(env, isdo->icm);
+        (*env)->DeleteGlobalRef(env, isdo->icm);
         isdo->icm = NULL;
     }
 
@@ -1848,13 +1848,13 @@ PRINT("Java_sun_java2d_OSXOffScreenSurfaceData_initRaster")
 
     // parameters specifying this image given to us from Java
     isdo->javaImageInfo                    = (jint*)((*env)->GetDirectBufferAddress(env, jImageInfo));
-    isdo->array                            = (array != NULL) ? JNFNewGlobalRef(env, array) : NULL;
+    isdo->array                            = (array != NULL) ? (*env)->NewGlobalRef(env, array) : NULL;
     isdo->offset                        = offset;
     isdo->width                            = width;
     isdo->height                        = height;
     isdo->javaPixelBytes                = pixelStride;
     isdo->javaPixelsBytesPerRow            = scanStride;
-    isdo->icm                            = (icm != NULL) ? JNFNewGlobalRef(env, icm) : NULL;
+    isdo->icm                            = (icm != NULL) ? (*env)->NewGlobalRef(env, icm) : NULL;
     isdo->type                            = type;
 
     if ((isdo->javaImageInfo[sun_java2d_OSXOffScreenSurfaceData_kImageStolenIndex] == 1) ||
@@ -1962,7 +1962,7 @@ PRINT("Java_sun_java2d_OSXOffScreenSurfaceData_initRaster")
     qsdo->FinishSurface                    = ImageSD_finishCGContext;
 
     qsdo->javaGraphicsStates            = (jint*)((*env)->GetDirectBufferAddress(env, jGraphicsState));
-    qsdo->javaGraphicsStatesObjects        = JNFNewGlobalRef(env, jGraphicsStateObject);
+    qsdo->javaGraphicsStatesObjects        = (*env)->NewGlobalRef(env, jGraphicsStateObject);
 
     qsdo->graphicsStateInfo.batchedLines = NULL;
     qsdo->graphicsStateInfo.batchedLinesCount = 0;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
@@ -36,9 +36,11 @@
 {
     self = [super init];
     if (self) {
-        fAccessibleAction = JNFNewWeakGlobalRef(env, accessibleAction);
+        fAccessibleAction = (*env)->NewWeakGlobalRef(env, accessibleAction);
+        CHECK_EXCEPTION();
         fIndex = index;
-        fComponent = JNFNewWeakGlobalRef(env, component);
+        fComponent = (*env)->NewWeakGlobalRef(env, component);
+        CHECK_EXCEPTION();
     }
     return self;
 }
@@ -47,10 +49,10 @@
 {
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
-    JNFDeleteWeakGlobalRef(env, fAccessibleAction);
+    (*env)->DeleteWeakGlobalRef(env, fAccessibleAction);
     fAccessibleAction = NULL;
 
-    JNFDeleteWeakGlobalRef(env, fComponent);
+    (*env)->DeleteWeakGlobalRef(env, fComponent);
     fComponent = NULL;
 
     [super dealloc];
@@ -63,14 +65,20 @@
     DECLARE_METHOD_RETURN(jm_getAccessibleActionDescription, sjc_CAccessibility, "getAccessibleActionDescription",
                           "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)Ljava/lang/String;", nil);
 
+    /* WeakGlobalRefs can be cleared at any time, so first get strong local refs and use those */
     jobject fCompLocal = (*env)->NewLocalRef(env, fComponent);
     if ((*env)->IsSameObject(env, fCompLocal, NULL)) {
+        return nil;
+    }
+    jobject fAccessibleActionLocal = (*env)->NewLocalRef(env, fAccessibleAction);
+    if ((*env)->IsSameObject(env, fAccessibleActionLocal, NULL)) {
+        (*env)->DeleteLocalRef(env, fCompLocal);
         return nil;
     }
     NSString *str = nil;
     jstring jstr = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
                                               jm_getAccessibleActionDescription,
-                                              fAccessibleAction,
+                                              fAccessibleActionLocal,
                                               fIndex,
                                               fCompLocal );
     CHECK_EXCEPTION();
@@ -79,6 +87,7 @@
         (*env)->DeleteLocalRef(env, jstr);
     }
     (*env)->DeleteLocalRef(env, fCompLocal);
+    (*env)->DeleteLocalRef(env, fAccessibleActionLocal);
     return str;
 }
 
@@ -103,9 +112,11 @@
 {
     self = [super init];
     if (self) {
-        fTabGroup = JNFNewWeakGlobalRef(env, tabGroup);
+        fTabGroup = (*env)->NewWeakGlobalRef(env, tabGroup);
+        CHECK_EXCEPTION();
         fIndex = index;
-        fComponent = JNFNewWeakGlobalRef(env, component);
+        fComponent = (*env)->NewWeakGlobalRef(env, component);
+        CHECK_EXCEPTION();
     }
     return self;
 }
@@ -114,10 +125,10 @@
 {
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
-    JNFDeleteWeakGlobalRef(env, fTabGroup);
+    (*env)->DeleteWeakGlobalRef(env, fTabGroup);
     fTabGroup = NULL;
 
-    JNFDeleteWeakGlobalRef(env, fComponent);
+    (*env)->DeleteWeakGlobalRef(env, fComponent);
     fComponent = NULL;
 
     [super dealloc];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -1833,7 +1833,8 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     self = [super initWithParent:parent withEnv:env withAccessible:accessible withIndex:index withView:view withJavaRole:javaRole];
     if (self) {
         if (tabGroup != NULL) {
-            fTabGroupAxContext = JNFNewWeakGlobalRef(env, tabGroup);
+            fTabGroupAxContext = (*env)->NewWeakGlobalRef(env, tabGroup);
+            CHECK_EXCEPTION();
         } else {
             fTabGroupAxContext = NULL;
         }
@@ -1846,7 +1847,7 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
     if (fTabGroupAxContext != NULL) {
-        JNFDeleteWeakGlobalRef(env, fTabGroupAxContext);
+        (*env)->DeleteWeakGlobalRef(env, fTabGroupAxContext);
         fTabGroupAxContext = NULL;
     }
 
@@ -1879,7 +1880,8 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component);
     if (fTabGroupAxContext == NULL) {
         JNIEnv* env = [ThreadUtilities getJNIEnv];
         jobject tabGroupAxContext = [(JavaComponentAccessibility *)[self parent] axContextWithEnv:env];
-        fTabGroupAxContext = JNFNewWeakGlobalRef(env, tabGroupAxContext);
+        fTabGroupAxContext = (*env)->NewWeakGlobalRef(env, tabGroupAxContext);
+        CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, tabGroupAxContext);
     }
     return fTabGroupAxContext;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -45,7 +45,7 @@ static jclass sjc_CPrinterJob = NULL;
     self = [super initWithFrame:aRect];
     if (self)
     {
-        fPrinterJob = JNFNewGlobalRef(env, printerJob);
+        fPrinterJob = (*env)->NewGlobalRef(env, printerJob);
         fCurPageFormat = NULL;
         fCurPainter = NULL;
         fCurPeekGraphics = NULL;
@@ -57,17 +57,17 @@ static jclass sjc_CPrinterJob = NULL;
 {
     if (fCurPageFormat != NULL)
     {
-        JNFDeleteGlobalRef(env, fCurPageFormat);
+        (*env)->DeleteGlobalRef(env, fCurPageFormat);
         fCurPageFormat = NULL;
     }
     if (fCurPainter != NULL)
     {
-        JNFDeleteGlobalRef(env, fCurPainter);
+        (*env)->DeleteGlobalRef(env, fCurPainter);
         fCurPainter = NULL;
     }
     if (fCurPeekGraphics != NULL)
     {
-        JNFDeleteGlobalRef(env, fCurPeekGraphics);
+        (*env)->DeleteGlobalRef(env, fCurPeekGraphics);
         fCurPeekGraphics = NULL;
     }
 }
@@ -166,7 +166,7 @@ static jclass sjc_CPrinterJob = NULL;
     DECLARE_CLASS_RETURN(sjc_PageFormat, "java/awt/print/PageFormat", NSZeroRect);
     DECLARE_METHOD_RETURN(jm_getOrientation, sjc_PageFormat, "getOrientation", "()I", NSZeroRect);
 
-    // Assertions removed, and corresponding JNFDeleteGlobalRefs added, for radr://3962543
+    // Assertions removed, and corresponding DeleteGlobalRefs added, for radr://3962543
     // Actual fix that will keep these assertions from being true is radr://3205462 ,
     // which will hopefully be fixed by the blocking AppKit bug radr://3056694
     //assert(fCurPageFormat == NULL);
@@ -174,13 +174,13 @@ static jclass sjc_CPrinterJob = NULL;
     //assert(fCurPeekGraphics == NULL);
 
     if(fCurPageFormat != NULL) {
-        JNFDeleteGlobalRef(env, fCurPageFormat);
+        (*env)->DeleteGlobalRef(env, fCurPageFormat);
     }
     if(fCurPainter != NULL) {
-        JNFDeleteGlobalRef(env, fCurPainter);
+        (*env)->DeleteGlobalRef(env, fCurPainter);
     }
     if(fCurPeekGraphics != NULL) {
-        JNFDeleteGlobalRef(env, fCurPeekGraphics);
+        (*env)->DeleteGlobalRef(env, fCurPeekGraphics);
     }
 
     //+++gdb Check the pageNumber for validity (PageAttrs)
@@ -201,15 +201,15 @@ static jclass sjc_CPrinterJob = NULL;
         // Get references to the return objects -> PageFormat, Printable, PeekGraphics
         // Cheat - we know we either got NULL or a 3 element array
         jobject pageFormat = (*env)->GetObjectArrayElement(env, objectArray, 0);
-        fCurPageFormat = JNFNewGlobalRef(env, pageFormat);
+        fCurPageFormat = (*env)->NewGlobalRef(env, pageFormat);
         (*env)->DeleteLocalRef(env, pageFormat);
 
         jobject painter = (*env)->GetObjectArrayElement(env, objectArray, 1);
-        fCurPainter = JNFNewGlobalRef(env, painter);
+        fCurPainter = (*env)->NewGlobalRef(env, painter);
         (*env)->DeleteLocalRef(env, painter);
 
         jobject peekGraphics = (*env)->GetObjectArrayElement(env, objectArray, 2);
-        fCurPeekGraphics = JNFNewGlobalRef(env, peekGraphics);
+        fCurPeekGraphics = (*env)->NewGlobalRef(env, peekGraphics);
         (*env)->DeleteLocalRef(env, peekGraphics);
 
         // Actually print and get the PageFormatArea
@@ -280,7 +280,7 @@ static jclass sjc_CPrinterJob = NULL;
     [self releaseReferences:env];
     if (fPrinterJob != NULL)
     {
-        JNFDeleteGlobalRef(env, fPrinterJob);
+        (*env)->DeleteGlobalRef(env, fPrinterJob);
         fPrinterJob = NULL;
     }
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.h
@@ -31,7 +31,7 @@
 @interface CGLLayer : CAOpenGLLayer
 {
 @private
-    JNFWeakJObjectWrapper *javaLayer;
+    jobject javaLayer;
 
     // intermediate buffer, used the RQ lock to synchronize
     GLuint textureID;
@@ -40,13 +40,13 @@
     float textureHeight;
 }
 
-@property (nonatomic, retain) JNFWeakJObjectWrapper *javaLayer;
+@property (nonatomic) jobject javaLayer;
 @property (readwrite, assign) GLuint textureID;
 @property (readwrite, assign) GLenum target;
 @property (readwrite, assign) float textureWidth;
 @property (readwrite, assign) float textureHeight;
 
-- (id) initWithJavaLayer:(JNFWeakJObjectWrapper *)javaLayer;
+- (id) initWithJavaLayer:(jobject)javaLayer;
 - (void) blitTexture;
 @end
 

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
@@ -65,13 +65,13 @@ static jint ns2awtMouseButton(NSInteger mouseButton) {
 {
 @public
     NSMenu *nsmenu;
-    JNFJObjectWrapper *javaObjectWrapper;
+    jobject javaObject;
 }
 
 @property (nonatomic, retain) NSMenu *nsmenu;
-@property (nonatomic, retain) JNFJObjectWrapper *javaObjectWrapper;
+@property (nonatomic) jobject javaObject;
 
-- (id)initFromMenu:(NSMenu *)menu javaObj:(JNFJObjectWrapper *)obj;
+- (id)initFromMenu:(NSMenu *)menu javaObj:(jobject)obj;
 - (NSMenu*)menu;
 @end
 
@@ -79,14 +79,14 @@ static jint ns2awtMouseButton(NSInteger mouseButton) {
 @implementation NativeToJavaDelegate
 
 @synthesize nsmenu;
-@synthesize javaObjectWrapper;
+@synthesize javaObject;
 
-- (id)initFromMenu:(NSMenu *)aMenu javaObj:(JNFJObjectWrapper *)obj
+- (id)initFromMenu:(NSMenu *)aMenu javaObj:(jobject)obj
 {
     self = [super init];
     if (self) {
         self.nsmenu = aMenu;
-        self.javaObjectWrapper = obj;
+        self.javaObject = obj;
     }
     return self;
 }
@@ -97,7 +97,7 @@ static jint ns2awtMouseButton(NSInteger mouseButton) {
 
 - (void)menuWillOpen:(NSMenu *)menu
 {
-    if (self.javaObjectWrapper == nil) {
+    if (self.javaObject == nil) {
 #ifdef DEBUG
         NSLog(@"_javaObject is NULL: (%s - %s : %d)", __FILE__, __FUNCTION__, __LINE__);
 #endif
@@ -109,7 +109,7 @@ JNI_COCOA_ENTER(env);
     //NSLog(@"menuWillOpen %@", [menu title]);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_invokeOpenLater, sjc_ScreenMenu, "invokeOpenLater", "()V");
-    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeOpenLater); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_invokeOpenLater); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
 JNI_COCOA_EXIT(env);
 
@@ -117,7 +117,7 @@ JNI_COCOA_EXIT(env);
 
 - (void)menuDidClose:(NSMenu *)menu
 {
-    if (self.javaObjectWrapper == nil) {
+    if (self.javaObject == nil) {
 #ifdef DEBUG
         NSLog(@"_javaObject is NULL: (%s - %s : %d)", __FILE__, __FUNCTION__, __LINE__);
 #endif
@@ -129,7 +129,7 @@ JNI_COCOA_ENTER(env);
     //NSLog(@"menuDidClose %@", [menu title]);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_invokeMenuClosing, sjc_ScreenMenu, "invokeMenuClosing", "()V");
-    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_invokeMenuClosing); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_invokeMenuClosing); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
 JNI_COCOA_EXIT(env);
 }
@@ -137,7 +137,7 @@ JNI_COCOA_EXIT(env);
 
 - (void)handleJavaMenuItemTargetedAtIndex:(NSUInteger)menuIndex rect:(NSRect)rect
 {
-    if (self.javaObjectWrapper == nil) {
+    if (self.javaObject== nil) {
 #ifdef DEBUG
         NSLog(@"_javaObject is NULL: (%s - %s : %d)", __FILE__, __FUNCTION__, __LINE__);
 #endif
@@ -149,7 +149,7 @@ JNI_COCOA_ENTER(env);
     // Send that to Java so we can test which item was hit.
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_updateSelectedItem, sjc_ScreenMenu, "handleItemTargeted", "(IIIII)V");
-    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_updateSelectedItem, menuIndex,
+    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_updateSelectedItem, menuIndex,
                     NSMinY(rect), NSMinX(rect), NSMaxY(rect), NSMaxX(rect)); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
 
@@ -194,7 +194,7 @@ JNI_COCOA_EXIT(env);
 JNI_COCOA_ENTER(env);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_handleMouseEvent, sjc_ScreenMenu, "handleMouseEvent", "(IIIIJ)V");
-    (*env)->CallVoidMethod(env, [self.javaObjectWrapper jObject], jm_ScreenMenu_handleMouseEvent,
+    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_handleMouseEvent,
              javaKind, javaX, javaY, javaModifiers, javaWhen); // AWT_THREADING Safe (AWTRunLoopMode)
     CHECK_EXCEPTION();
 JNI_COCOA_EXIT(env);
@@ -215,10 +215,10 @@ JNIEXPORT jlong JNICALL Java_com_apple_laf_ScreenMenu_addMenuListeners
 
 JNI_COCOA_ENTER(env);
 
-    JNFJObjectWrapper *wrapper = [JNFJObjectWrapper wrapperWithJObject:listener withEnv:env];
+    jobject listenerRef = (*env)->NewGlobalRef(env, listener);
     NSMenu *menu = jlong_to_ptr(nativeMenu);
 
-    delegate = [[[NativeToJavaDelegate alloc] initFromMenu:menu javaObj:wrapper] autorelease];
+    delegate = [[[NativeToJavaDelegate alloc] initFromMenu:menu javaObj:listenerRef] autorelease];
     CFRetain(delegate); // GC
 
     [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^{
@@ -253,8 +253,10 @@ JNI_COCOA_ENTER(env);
         [menu setJavaMenuDelegate:nil];
         [menu setDelegate:nil];
         delegate.nsmenu = nil;
-        delegate.javaObjectWrapper = nil;
     }];
+
+    (*env)->DeleteGlobalRef(env, delegate.javaObject);
+    delegate.javaObject = nil;
 
     CFRelease(delegate); // GC
 


### PR DESCRIPTION
Clean backport to jdk15u-dev, part 6 of 8 JNF-removal patches

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259869](https://bugs.openjdk.java.net/browse/JDK-8259869): [macOS] Remove desktop module dependencies on JNF Reference APIs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/12.diff">https://git.openjdk.java.net/jdk15u-dev/pull/12.diff</a>

</details>
