### PR TITLE
8260616: Removing remaining JNF dependencies in the java.desktop module

### DIFF
--- a/make/modules/java.desktop/Lib.gmk
+++ b/make/modules/java.desktop/Lib.gmk
@@ -101,7 +101,6 @@ ifeq ($(call isTargetOs, macosx), true)
           -framework Cocoa \
           -framework Security \
           -framework ExceptionHandling \
-          -framework JavaNativeFoundation \
           -framework JavaRuntimeSupport \
           -framework OpenGL \
           -framework IOSurface \
@@ -127,7 +126,6 @@ ifeq ($(call isTargetOs, macosx), true)
           -losxapp \
           -framework Cocoa \
           -framework ApplicationServices \
-          -framework JavaNativeFoundation \
           -framework JavaRuntimeSupport \
           -framework SystemConfiguration \
           $(JDKLIB_LIBS), \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -160,7 +160,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
     LIBS_macosx := -lmlib_image \
         -framework Cocoa \
         -framework OpenGL \
-        -framework JavaNativeFoundation \
         -framework JavaRuntimeSupport \
         -framework ApplicationServices \
         -framework AudioToolbox, \
@@ -715,8 +714,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
         -framework ApplicationServices \
         -framework Foundation \
         -framework Security \
-        -framework Cocoa \
-        -framework JavaNativeFoundation
+        -framework Cocoa
   else ifeq ($(call isTargetOs, windows), true)
     LIBSPLASHSCREEN_LIBS += kernel32.lib user32.lib gdi32.lib delayimp.lib $(WIN_JAVA_LIB) jvm.lib
   else
@@ -813,7 +811,6 @@ ifeq ($(call isTargetOs, macosx), true)
           -framework Cocoa \
           -framework Security \
           -framework ExceptionHandling \
-          -framework JavaNativeFoundation \
           -framework JavaRuntimeSupport \
           -framework OpenGL \
           -framework QuartzCore -ljava, \
@@ -851,7 +848,6 @@ ifeq ($(call isTargetOs, macosx), true)
           -framework Cocoa \
           -framework Carbon \
           -framework ApplicationServices \
-          -framework JavaNativeFoundation \
           -framework JavaRuntimeSupport \
           -ljava -ljvm, \
   ))

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -78,7 +78,7 @@ endif
 ifeq ($(call isTargetOs, macosx), true)
   BUILD_JDK_JTREG_EXCLUDE += exelauncher.c
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libTestMainKeyWindow := \
-      -framework Cocoa -framework JavaNativeFoundation
+      -framework Cocoa
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJniInvocationTest := -ljli
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libTestDynamicStore := \
       -framework Cocoa -framework SystemConfiguration

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -29,7 +29,6 @@
 
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <sys/time.h>
 #import <Carbon/Carbon.h>
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTSurfaceLayers.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTSurfaceLayers.m
@@ -28,7 +28,6 @@
 #import "LWCToolkit.h"
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <QuartzCore/CATransaction.h>
 
 @implementation AWTSurfaceLayers

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -36,7 +36,6 @@
 #import "JNIUtilities.h"
 
 #import <Carbon/Carbon.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
@@ -136,7 +135,7 @@ static BOOL shouldUsePressAndHold() {
 
     [AWTToolkit eventCountPlusPlus];
 
-    [JNFRunLoop performOnMainThreadWaiting:NO withBlock:^() {
+    [ThreadUtilities performOnMainThreadWaiting:NO block:^() {
         [[self window] makeFirstResponder: self];
     }];
     if ([self window] != NULL) {
@@ -462,8 +461,8 @@ static BOOL shouldUsePressAndHold() {
     jstring characters = NULL;
     jstring charactersIgnoringModifiers = NULL;
     if ([event type] != NSFlagsChanged) {
-        characters = JNFNSToJavaString(env, [event characters]);
-        charactersIgnoringModifiers = JNFNSToJavaString(env, [event charactersIgnoringModifiers]);
+        characters = NSStringToJavaString(env, [event characters]);
+        charactersIgnoringModifiers = NSStringToJavaString(env, [event charactersIgnoringModifiers]);
     }
 
     DECLARE_CLASS(jc_NSEvent, "sun/lwawt/macosx/NSEvent");
@@ -576,10 +575,7 @@ static BOOL shouldUsePressAndHold() {
     DECLARE_FIELD_RETURN(jf_Peer, jc_CPlatformView, "peer", "Lsun/lwawt/LWWindowPeer;", NULL);
     if ((env == NULL) || (m_cPlatformView == NULL)) {
         NSLog(@"Apple AWT : Error AWTView:awtComponent given bad parameters.");
-        if (env != NULL)
-        {
-            JNFDumpJavaStack(env);
-        }
+        NSLog(@"%@",[NSThread callStackSymbols]);
         return NULL;
     }
 
@@ -593,7 +589,7 @@ static BOOL shouldUsePressAndHold() {
     DECLARE_FIELD_RETURN(jf_Target, jc_LWWindowPeer, "target", "Ljava/awt/Component;", NULL);
     if (peer == NULL) {
         NSLog(@"Apple AWT : Error AWTView:awtComponent got null peer from CPlatformView");
-        JNFDumpJavaStack(env);
+        NSLog(@"%@",[NSThread callStackSymbols]);
         return NULL;
     }
     jobject comp = (*env)->GetObjectField(env, peer, jf_Target);
@@ -990,8 +986,8 @@ static jclass jc_CInputMethod = NULL;
         }
 
         DECLARE_METHOD(jm_insertText, jc_CInputMethod, "insertText", "(Ljava/lang/String;)V");
-        jstring insertedText =  JNFNSToJavaString(env, useString);
-        (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_insertText, insertedText); // AWT_THREADING Safe (AWTRunLoopMode)
+        jstring insertedText =  NSStringToJavaString(env, useString);
+        (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_insertText, insertedText);
         CHECK_EXCEPTION();
         (*env)->DeleteLocalRef(env, insertedText);
 
@@ -1056,8 +1052,8 @@ static jclass jc_CInputMethod = NULL;
     // NSInputContext already did the analysis of the TSM event and created attributes indicating
     // the underlining and color that should be done to the string.  We need to look at the underline
     // style and color to determine what kind of Java hilighting needs to be done.
-    jstring inProcessText = JNFNSToJavaString(env, incomingString);
-    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_startIMUpdate, inProcessText); // AWT_THREADING Safe (AWTRunLoopMode)
+    jstring inProcessText = NSStringToJavaString(env, incomingString);
+    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_startIMUpdate, inProcessText);
     CHECK_EXCEPTION();
     (*env)->DeleteLocalRef(env, inProcessText);
 
@@ -1082,7 +1078,7 @@ static jclass jc_CInputMethod = NULL;
                 isGray = !([underlineColorObj isEqual:[NSColor blackColor]]);
 
                 (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_addAttribute, isThickUnderline,
-                       isGray, effectiveRange.location, effectiveRange.length); // AWT_THREADING Safe (AWTRunLoopMode)
+                       isGray, effectiveRange.location, effectiveRange.length);
                 CHECK_EXCEPTION();
             }
         }
@@ -1097,7 +1093,7 @@ static jclass jc_CInputMethod = NULL;
     }
 
     (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_dispatchText,
-            selectionRange.location, selectionRange.length, JNI_FALSE); // AWT_THREADING Safe (AWTRunLoopMode)
+            selectionRange.location, selectionRange.length, JNI_FALSE);
          CHECK_EXCEPTION();
     // If the marked text is being cleared (zero-length string) don't handle the key event.
     if ([incomingString length] == 0) {
@@ -1119,7 +1115,7 @@ static jclass jc_CInputMethod = NULL;
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_CIM_CLASS();
     DECLARE_METHOD(jm_unmarkText, jc_CInputMethod, "unmarkText", "()V");
-    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_unmarkText); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallVoidMethod(env, fInputMethodLOCKABLE, jm_unmarkText);
     CHECK_EXCEPTION();
 }
 
@@ -1172,10 +1168,10 @@ static jclass jc_CInputMethod = NULL;
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     DECLARE_METHOD_RETURN(jm_substringFromRange, jc_CInputMethod, "attributedSubstringFromRange", "(II)Ljava/lang/String;", nil);
-    jobject theString = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_substringFromRange, theRange.location, theRange.length); // AWT_THREADING Safe (AWTRunLoopMode)
+    jobject theString = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_substringFromRange, theRange.location, theRange.length);
     CHECK_EXCEPTION_NULL_RETURN(theString, nil);
 
-    id result = [[[NSAttributedString alloc] initWithString:JNFJavaToNSString(env, theString)] autorelease];
+    id result = [[[NSAttributedString alloc] initWithString:JavaStringToNSString(env, theString)] autorelease];
 #ifdef IM_DEBUG
     NSLog(@"attributedSubstringFromRange returning \"%@\"", result);
 #endif // IM_DEBUG
@@ -1206,7 +1202,7 @@ static jclass jc_CInputMethod = NULL;
     GET_CIM_CLASS_RETURN(range);
     DECLARE_METHOD_RETURN(jm_markedRange, jc_CInputMethod, "markedRange", "()[I", range);
 
-    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_markedRange); // AWT_THREADING Safe (AWTRunLoopMode)
+    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_markedRange);
     CHECK_EXCEPTION();
 
     if (array) {
@@ -1247,7 +1243,7 @@ static jclass jc_CInputMethod = NULL;
     fprintf(stderr, "AWTView InputMethod Selector Called : [selectedRange]\n");
 #endif // IM_DEBUG
 
-    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_selectedRange); // AWT_THREADING Safe (AWTRunLoopMode)
+    array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_selectedRange);
     CHECK_EXCEPTION();
     if (array) {
         _array = (*env)->GetIntArrayElements(env, array, &isCopy);
@@ -1286,7 +1282,7 @@ static jclass jc_CInputMethod = NULL;
 #endif // IM_DEBUG
 
     array = (*env)->CallObjectMethod(env, fInputMethodLOCKABLE, jm_firstRectForCharacterRange,
-                                theRange.location); // AWT_THREADING Safe (AWTRunLoopMode)
+                                theRange.location);
     CHECK_EXCEPTION();
 
     _array = (*env)->GetIntArrayElements(env, array, &isCopy);
@@ -1327,7 +1323,7 @@ static jclass jc_CInputMethod = NULL;
 #endif // IM_DEBUG
 
     jint index = (*env)->CallIntMethod(env, fInputMethodLOCKABLE, jm_characterIndexForPoint,
-                      (jint)flippedLocation.x, (jint)flippedLocation.y); // AWT_THREADING Safe (AWTRunLoopMode)
+                      (jint)flippedLocation.x, (jint)flippedLocation.y);
     CHECK_EXCEPTION();
 
 #ifdef IM_DEBUG

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -24,7 +24,6 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "sun_lwawt_macosx_CPlatformWindow.h"
 #import "com_apple_eawt_event_GestureHandler.h"
@@ -1444,7 +1443,7 @@ JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
     [nsWindow performSelectorOnMainThread:@selector(setTitle:)
-                              withObject:JNFJavaToNSString(env, jtitle)
+                              withObject:JavaStringToNSString(env, jtitle)
                            waitUntilDone:NO];
 
 JNI_COCOA_EXIT(env);
@@ -1520,7 +1519,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CPlatformWindow_nativeSetNSWindowRe
 JNI_COCOA_ENTER(env);
 
     NSWindow *nsWindow = OBJC(windowPtr);
-    NSURL *url = (filename == NULL) ? nil : [NSURL fileURLWithPath:JNFNormalizedNSStringForPath(env, filename)];
+    NSURL *url = (filename == NULL) ? nil : [NSURL fileURLWithPath:NormalizedPathNSStringFromJavaString(env, filename)];
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [nsWindow setRepresentedURL:url];
     }];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -27,7 +27,6 @@
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 @interface CClipboard : NSObject { }
 @property NSInteger changeCount;
@@ -99,7 +98,7 @@
         DECLARE_METHOD(jm_lostOwnership, jc_CClipboard, "notifyLostOwnership", "()V");
         @synchronized(self) {
             if (self.clipboardOwner) {
-                (*env)->CallVoidMethod(env, self.clipboardOwner, jm_lostOwnership); // AWT_THREADING Safe (event)
+                (*env)->CallVoidMethod(env, self.clipboardOwner, jm_lostOwnership);
                 CHECK_EXCEPTION();
                 (*env)->DeleteGlobalRef(env, self.clipboardOwner);
                 self.clipboardOwner = NULL;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CCursorManager.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CCursorManager.m
@@ -26,7 +26,6 @@
 #include "sun_lwawt_macosx_CCursorManager.h"
 
 #include <Cocoa/Cocoa.h>
-#include <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #include "GeomUtilities.h"
 #include "ThreadUtilities.h"
@@ -75,7 +74,7 @@ Java_sun_lwawt_macosx_CCursorManager_nativeSetBuiltInCursor
 {
 JNI_COCOA_ENTER(env);
 
-    NSString *cursorName = JNFJavaToNSString(env, name);
+    NSString *cursorName = JavaStringToNSString(env, name);
     SEL cursorSelector = (type == sun_lwawt_macosx_CCursorManager_NAMED_CURSOR) ? lookupCursorSelectorForName(cursorName) : lookupCursorSelectorForType(type);
     if (cursorSelector == nil) {
         NSString *reason = [NSString stringWithFormat:@"unimplemented built-in cursor type: %d / %@", type, cursorName];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDataTransferer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDataTransferer.m
@@ -28,9 +28,6 @@
 
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
-
 // ***** NOTE ***** This dictionary corresponds to the static array predefinedClipboardNames
 // in CDataTransferer.java.
 NSMutableDictionary *sStandardMappings = nil;
@@ -110,7 +107,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CDataTransferer_registerFormatWith
 {
     jlong returnValue = -1;
 JNI_COCOA_ENTER(env);
-    returnValue = registerFormatWithPasteboard(JNFJavaToNSString(env, newformat));
+    returnValue = registerFormatWithPasteboard(JavaStringToNSString(env, newformat));
 JNI_COCOA_EXIT(env);
     return returnValue;
 }
@@ -125,7 +122,7 @@ JNIEXPORT jstring JNICALL Java_sun_lwawt_macosx_CDataTransferer_formatForIndex
 {
     jstring returnValue = NULL;
 JNI_COCOA_ENTER(env);
-    returnValue = JNFNSToJavaString(env, formatForIndex(index));
+    returnValue = NSStringToJavaString(env, formatForIndex(index));
 JNI_COCOA_EXIT(env);
     return returnValue;
 }
@@ -138,7 +135,7 @@ static jobjectArray CreateJavaFilenameArray(JNIEnv *env, NSArray *filenameArray)
     // Get the java.lang.String class object:
     jclass stringClazz = (*env)->FindClass(env, "java/lang/String");
     CHECK_NULL_RETURN(stringClazz, nil);
-    jobject jfilenameArray = (*env)->NewObjectArray(env, filenameCount, stringClazz, NULL); // AWT_THREADING Safe (known object)
+    jobject jfilenameArray = (*env)->NewObjectArray(env, filenameCount, stringClazz, NULL);
     if ((*env)->ExceptionOccurred(env)) {
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDesktopPeer.m
@@ -27,7 +27,6 @@
 #import "JNIUtilities.h"
 #import <CoreFoundation/CoreFoundation.h>
 #import <ApplicationServices/ApplicationServices.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 /*
  * Class:     sun_lwawt_macosx_CDesktopPeer
@@ -43,7 +42,7 @@ JNI_COCOA_ENTER(env);
     // I would love to use NSWorkspace here, but it's not thread safe. Why? I don't know.
     // So we use LaunchServices directly.
 
-    NSURL *url = [NSURL URLWithString:JNFJavaToNSString(env, uri)];
+    NSURL *url = [NSURL URLWithString:JavaStringToNSString(env, uri)];
 
     LSLaunchFlags flags = kLSLaunchDefaults;
 
@@ -68,7 +67,7 @@ JNI_COCOA_ENTER(env);
     // I would love to use NSWorkspace here, but it's not thread safe. Why? I don't know.
     // So we use LaunchServices directly.
 
-    NSString *path  = JNFNormalizedNSStringForPath(env, jpath);
+    NSString *path  = NormalizedPathNSStringFromJavaString(env, jpath);
 
     NSURL *url = [NSURL fileURLWithPath:(NSString *)path];
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSource.m
@@ -28,7 +28,6 @@
 #import "java_awt_dnd_DnDConstants.h"
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "AWTEvent.h"
 #import "AWTView.h"
@@ -572,7 +571,7 @@ static BOOL                sNeedsEnter;
         GET_DSCP_CLASS();
         DECLARE_METHOD(dragDropFinishedMethod, CDragSourceContextPeerClass, "dragDropFinished", "(ZIII)V");
         DLog3(@"  -> posting dragDropFinished, point %f, %f", point.x, point.y);
-        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragDropFinishedMethod, success, dragOp, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragDropFinishedMethod, success, dragOp, (jint) point.x, (jint) point.y);
         CHECK_EXCEPTION();
         DECLARE_METHOD(resetHoveringMethod, CDragSourceContextPeerClass, "resetHovering", "()V");
         (*env)->CallVoidMethod(env, fDragSourceContextPeer, resetHoveringMethod); // Hust reset static variable
@@ -594,7 +593,7 @@ static BOOL                sNeedsEnter;
 {
     AWT_ASSERT_NOT_APPKIT_THREAD;
 
-    [self performSelectorOnMainThread:@selector(doDrag) withObject:nil waitUntilDone:YES]; // AWT_THREADING Safe (called from unique asynchronous thread)
+    [self performSelectorOnMainThread:@selector(doDrag) withObject:nil waitUntilDone:YES];
 }
 
 /********************************  BEGIN NSDraggingSource Interface  ********************************/
@@ -613,7 +612,7 @@ static BOOL                sNeedsEnter;
 
     GET_DSCP_CLASS();
     DECLARE_METHOD(operationChangedMethod, CDragSourceContextPeerClass, "operationChanged", "(IIII)V");
-    (*env)->CallVoidMethod(env, fDragSourceContextPeer, operationChangedMethod, targetActions, modifiedModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    (*env)->CallVoidMethod(env, fDragSourceContextPeer, operationChangedMethod, targetActions, modifiedModifiers, (jint) point.x, (jint) point.y);
     CHECK_EXCEPTION();
 }
 
@@ -688,11 +687,11 @@ JNI_COCOA_ENTER(env);
         DLog3(@"  -> posting dragMotion, point %f, %f", point.x, point.y);
         GET_DSCP_CLASS();
         DECLARE_METHOD(dragMotionMethod, CDragSourceContextPeerClass, "dragMotion", "(IIII)V");
-        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMotionMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMotionMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y);
         CHECK_EXCEPTION();
         DLog3(@"  -> posting dragMouseMoved, point %f, %f", point.x, point.y);
         DECLARE_METHOD(dragMouseMovedMethod, CDragSourceContextPeerClass, "dragMouseMoved", "(IIII)V");
-        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMouseMovedMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+        (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragMouseMovedMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y);
         CHECK_EXCEPTION();
     }
 JNI_COCOA_EXIT(env);
@@ -719,7 +718,7 @@ JNI_COCOA_EXIT(env);
     DLog3(@"  -> posting dragEnter, point %f, %f", point.x, point.y);
     GET_DSCP_CLASS();
     DECLARE_METHOD(dragEnterMethod, CDragSourceContextPeerClass, "dragEnter", "(IIII)V");
-    (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragEnterMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragEnterMethod, targetActions, (jint) fModifiers, (jint) point.x, (jint) point.y);
      CHECK_EXCEPTION();
 }
 
@@ -731,7 +730,7 @@ JNI_COCOA_EXIT(env);
     DLog3(@"  -> posting dragExit, point %f, %f", point.x, point.y);
     GET_DSCP_CLASS();
     DECLARE_METHOD(dragExitMethod, CDragSourceContextPeerClass, "dragExit", "(II)V");
-    (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragExitMethod, (jint) point.x, (jint) point.y); // AWT_THREADING Safe (event)
+    (*env)->CallVoidMethod(env, fDragSourceContextPeer, dragExitMethod, (jint) point.x, (jint) point.y);
     CHECK_EXCEPTION();
 
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSourceContextPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDragSourceContextPeer.m
@@ -26,7 +26,6 @@
 #import "sun_lwawt_macosx_CDragSourceContextPeer.h"
 
 #import "JNIUtilities.h"
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "CDragSource.h"
 #import "ThreadUtilities.h"

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTarget.m
@@ -31,7 +31,6 @@
 #import "sun_lwawt_macosx_CDropTarget.h"
 #import "java_awt_dnd_DnDConstants.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 #include <objc/objc-runtime.h>
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTargetContextPeer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CDropTargetContextPeer.m
@@ -25,8 +25,6 @@
 
 #import "sun_lwawt_macosx_CDropTargetContextPeer.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #import "CDataTransferer.h"
 #import "CDropTarget.h"
 #import "DnDUtilities.h"

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CFRetainedResource.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CFRetainedResource.m
@@ -24,9 +24,9 @@
  */
 
 #import "JNIUtilities.h"
+#import "ThreadUtilities.h"
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "sun_lwawt_macosx_CFRetainedResource.h"
 
@@ -49,7 +49,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CFRetainedResource_nativeCFRelease
             }];
         } else {
             // could happen if we are embedded inside SWT/FX application,
-            [JNFRunLoop performOnMainThreadWaiting:NO withBlock:^() {
+            [ThreadUtilities performOnMainThreadWaiting:NO block:^() {
                 CFRelease(jlong_to_ptr(ptr));
             }];
         }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CFileDialog.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CFileDialog.h
@@ -24,7 +24,6 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 @interface CFileDialog : NSObject <NSOpenSavePanelDelegate> {
     // Should we query back to Java for a file filter?

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -28,8 +28,6 @@
 #include "GeomUtilities.h"
 #include "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 /**
  * Some default values for invalid CoreGraphics display ID.
  */

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsEnv.m
@@ -28,8 +28,6 @@
 #import "JNIUtilities.h"
 #import "ThreadUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #define MAX_DISPLAYS 64
 
 /*
@@ -114,19 +112,18 @@ static void displaycb_handle
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^() {
 
-        JNFPerformEnvBlock(JNFThreadDetachImmediately, ^(JNIEnv *env) {
-            jobject cgeRef = (jobject)userInfo;
+        JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
+        jobject cgeRef = (jobject)userInfo;
 
-            jobject graphicsEnv = (*env)->NewLocalRef(env, cgeRef);
-            if (graphicsEnv == NULL) return; // ref already GC'd
-            DECLARE_CLASS(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
-            DECLARE_METHOD(jm_displayReconfiguration,
-                    jc_CGraphicsEnvironment, "_displayReconfiguration","(IZ)V");
-            (*env)->CallVoidMethod(env, graphicsEnv, jm_displayReconfiguration,
-                    (jint) display, (jboolean) flags & kCGDisplayRemoveFlag);
-            (*env)->DeleteLocalRef(env, graphicsEnv);
-            CHECK_EXCEPTION();
-        });
+        jobject graphicsEnv = (*env)->NewLocalRef(env, cgeRef);
+        if (graphicsEnv == NULL) return; // ref already GC'd
+        DECLARE_CLASS(jc_CGraphicsEnvironment, "sun/awt/CGraphicsEnvironment");
+        DECLARE_METHOD(jm_displayReconfiguration,
+                jc_CGraphicsEnvironment, "_displayReconfiguration","(IZ)V");
+        (*env)->CallVoidMethod(env, graphicsEnv, jm_displayReconfiguration,
+                (jint) display, (jboolean) flags & kCGDisplayRemoveFlag);
+        (*env)->DeleteLocalRef(env, graphicsEnv);
+        CHECK_EXCEPTION();
     }];
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CImage.m
@@ -25,7 +25,6 @@
 #import "jni_util.h"
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "GeomUtilities.h"
 #import "ThreadUtilities.h"
@@ -204,7 +203,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromFile
 
 JNI_COCOA_ENTER(env);
 
-    NSString *path = JNFNormalizedNSStringForPath(env, file);
+    NSString *path = NormalizedPathNSStringFromJavaString(env, file);
     image = [[NSImage alloc] initByReferencingFile:path];
 
 JNI_COCOA_EXIT(env);
@@ -224,7 +223,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageOfFileFr
 
 JNI_COCOA_ENTER(env);
 
-    NSString *path = JNFNormalizedNSStringForPath(env, file);
+    NSString *path = NormalizedPathNSStringFromJavaString(env, file);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         image = [[[NSWorkspace sharedWorkspace] iconForFile:path] retain];
         [image setScalesWhenResized:TRUE];
@@ -247,7 +246,7 @@ JNIEXPORT jlong JNICALL Java_sun_lwawt_macosx_CImage_nativeCreateNSImageFromImag
 
 JNI_COCOA_ENTER(env);
 
-    image = [[NSImage imageNamed:JNFJavaToNSString(env, name)] retain];
+    image = [[NSImage imageNamed:JavaStringToNSString(env, name)] retain];
 
 JNI_COCOA_EXIT(env);
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
@@ -32,7 +32,6 @@
 #import "AWTView.h"
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #define JAVA_LIST @"JAVA_LIST"
@@ -160,7 +159,7 @@ JNI_COCOA_ENTER(env);
     }];
 
     if (keyboardInfo == nil) return NULL;
-    returnValue = JNFNSToJavaString(env, keyboardInfo);
+    returnValue = NSStringToJavaString(env, keyboardInfo);
     [keyboardInfo release];
 
 JNI_COCOA_EXIT(env);
@@ -259,7 +258,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CInputMethod_setNativeLocale
 (JNIEnv *env, jobject this, jstring locale, jboolean isActivating)
 {
 JNI_COCOA_ENTER(env);
-    NSString *localeStr = JNFJavaToNSString(env, locale);
+    NSString *localeStr = JavaStringToNSString(env, locale);
     [localeStr retain];
 
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenu.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenu.m
@@ -23,7 +23,6 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 
@@ -216,7 +215,7 @@ Java_sun_lwawt_macosx_CMenu_nativeSetMenuTitle
 {
 JNI_COCOA_ENTER(env);
     // Set the menu's title.
-    [((CMenu *)jlong_to_ptr(menuObject)) setJavaMenuTitle:JNFJavaToNSString(env, label)];
+    [((CMenu *)jlong_to_ptr(menuObject)) setJavaMenuTitle:JavaStringToNSString(env, label)];
 JNI_COCOA_EXIT(env);
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
@@ -26,7 +26,6 @@
 #import "JNIUtilities.h"
 
 #import <AppKit/AppKit.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuComponent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuComponent.m
@@ -24,7 +24,6 @@
  */
 
 #import "CMenuComponent.h"
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "ThreadUtilities.h"
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
@@ -23,7 +23,6 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #include <Carbon/Carbon.h>
 #import "CMenuItem.h"
 #import "CMenu.h"
@@ -313,7 +312,7 @@ Java_sun_lwawt_macosx_CMenuItem_nativeSetLabel
  jchar shortcutKey, jint shortcutKeyCode, jint mods)
 {
     JNI_COCOA_ENTER(env);
-    NSString *theLabel = JNFJavaToNSString(env, label);
+    NSString *theLabel = JavaStringToNSString(env, label);
     NSString *theKeyEquivalent = nil;
     unichar macKey = shortcutKey;
 
@@ -342,7 +341,7 @@ Java_sun_lwawt_macosx_CMenuItem_nativeSetTooltip
 (JNIEnv *env, jobject peer, jlong menuItemObj, jstring tooltip)
 {
     JNI_COCOA_ENTER(env);
-    NSString *theTooltip = JNFJavaToNSString(env, tooltip);
+    NSString *theTooltip = JavaStringToNSString(env, tooltip);
     [((CMenuItem *)jlong_to_ptr(menuItemObj)) setJavaToolTipText:theTooltip];
     JNI_COCOA_EXIT(env);
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPopupMenu.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPopupMenu.m
@@ -24,7 +24,6 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "AWTWindow.h"
 #import "AWTView.h"

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CPrinterJob.m
@@ -30,7 +30,6 @@
 #import "sun_lwawt_macosx_CPrinterPageDialog.h"
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "PrinterView.h"
 #import "PrintModel.h"
@@ -87,7 +86,7 @@ static NSPrintInfo* createDefaultNSPrintInfo(JNIEnv* env, jstring printer)
     NSPrintInfo* defaultPrintInfo = [[NSPrintInfo sharedPrintInfo] copy];
     if (printer != NULL)
     {
-        NSPrinter* nsPrinter = [NSPrinter printerWithName:JNFJavaToNSString(env, printer)];
+        NSPrinter* nsPrinter = [NSPrinter printerWithName:JavaStringToNSString(env, printer)];
         if (nsPrinter != nil)
         {
             [defaultPrintInfo setPrinter:nsPrinter];
@@ -345,7 +344,7 @@ static void javaPageFormatToNSPrintInfo(JNIEnv* env, jobject srcPrintJob, jobjec
     jobject printerNameObj = (*env)->CallObjectMethod(env, srcPrintJob, jm_getPrinterName);
     CHECK_EXCEPTION();
     if (printerNameObj == NULL) return;
-    NSString *printerName = JNFJavaToNSString(env, printerNameObj);
+    NSString *printerName = JavaStringToNSString(env, printerNameObj);
     if (printerName == nil) return;
     NSPrinter *printer = [NSPrinter printerWithName:printerName];
     if (printer == nil) return;
@@ -371,7 +370,7 @@ static void nsPrintInfoToJavaPrinterJob(JNIEnv* env, NSPrintInfo* src, jobject d
 
     // get the selected printer's name, and set the appropriate PrintService on the Java side
     NSString *name = [[src printer] name];
-    jstring printerName = JNFNSToJavaString(env, name);
+    jstring printerName = NSStringToJavaString(env, name);
     (*env)->CallVoidMethod(env, dstPrinterJob, jm_setService, printerName);
     CHECK_EXCEPTION();
 
@@ -615,7 +614,7 @@ JNI_COCOA_ENTER(env);
         jobject printerNameObj = (*env)->CallObjectMethod(env, jthis, jm_getPrinterName);
         CHECK_EXCEPTION();
         if (printerNameObj != NULL) {
-            NSString *printerName = JNFJavaToNSString(env, printerNameObj);
+            NSString *printerName = JavaStringToNSString(env, printerNameObj);
             if (printerName != nil) {
                 NSPrinter *printer = [NSPrinter printerWithName:printerName];
                 if (printer != nil) [printInfo setPrinter:printer];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CRobot.m
@@ -25,7 +25,6 @@
 
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <ApplicationServices/ApplicationServices.h>
 
 #import "CRobotKeyCode.h"

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
@@ -28,7 +28,6 @@
 #import "java_awt_SystemColor.h"
 #import "sun_lwawt_macosx_LWCToolkit.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import "ThreadUtilities.h"

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CTrayIcon.m
@@ -26,7 +26,6 @@
 #import "jni_util.h"
 
 #import <AppKit/AppKit.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "CTrayIcon.h"
 #import "ThreadUtilities.h"
@@ -366,7 +365,7 @@ JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CTrayIcon_nativeSetToolTip
 JNI_COCOA_ENTER(env);
 
     AWTTrayIcon *icon = jlong_to_ptr(model);
-    NSString *tooltip = JNFJavaToNSString(env, jtooltip);
+    NSString *tooltip = JavaStringToNSString(env, jtooltip);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [icon setTooltip:tooltip];
     }];
@@ -419,8 +418,8 @@ Java_sun_lwawt_macosx_CTrayIcon_nativeShowNotification
 JNI_COCOA_ENTER(env);
 
     AWTTrayIcon *icon = jlong_to_ptr(model);
-    NSString *caption = JNFJavaToNSString(env, jcaption);
-    NSString *text = JNFJavaToNSString(env, jtext);
+    NSString *caption = JavaStringToNSString(env, jcaption);
+    NSString *text = JavaStringToNSString(env, jtext);
     NSImage * contentImage = jlong_to_ptr(nsimage);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CWrapper.m
@@ -25,7 +25,6 @@
 
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import "ThreadUtilities.h"
 #import "sun_lwawt_macosx_CWrapper_NSWindow.h"
 
@@ -592,7 +591,7 @@ Java_sun_lwawt_macosx_CWrapper_00024NSView_setToolTip
 JNI_COCOA_ENTER(env);
 
     NSView *view = (NSView *)jlong_to_ptr(viewPtr);
-    NSString* s = JNFJavaToNSString(env, msg);
+    NSString* s = JavaStringToNSString(env, msg);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         [view setToolTip: s];
     }];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/GeomUtilities.m
@@ -100,7 +100,10 @@ NSSize JavaToNSSize(JNIEnv *env, jobject dimension) {
 static NSScreen *primaryScreen(JNIEnv *env) {
     NSScreen *primaryScreen = [[NSScreen screens] objectAtIndex:0];
     if (primaryScreen != nil) return primaryScreen;
-    if (env != NULL) [JNFException raise:env as:kRuntimeException reason:"Failed to convert, no screen."];
+    if ((env != NULL) && ([NSThread isMainThread] == NO)) {
+        JNU_ThrowByName(env, "java/lang/RuntimeException", "Failed to convert, no screen.");
+    }
+    [NSException raise:NSGenericException format:@"Failed to convert, no screen."];
     return nil;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ImageSurfaceData.m
@@ -32,7 +32,6 @@
 
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "BufImgSurfaceData.h"
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
@@ -83,7 +83,7 @@
                                               fCompLocal );
     CHECK_EXCEPTION();
     if (jstr != NULL) {
-        str = JNFJavaToNSString(env, jstr); // AWT_THREADING Safe (AWTRunLoopMode)
+        str = JavaStringToNSString(env, jstr);
         (*env)->DeleteLocalRef(env, jstr);
     }
     (*env)->DeleteLocalRef(env, fCompLocal);
@@ -99,7 +99,7 @@
                     "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V");
 
     (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_doAccessibleAction,
-             fAccessibleAction, fIndex, fComponent); // AWT_THREADING Safe (AWTRunLoopMode)
+             fAccessibleAction, fIndex, fComponent);
     CHECK_EXCEPTION();
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.h
@@ -23,7 +23,7 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
+#import "JNIUtilities.h"
 
 extern NSString *const JavaAccessibilityIgnore;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityUtilities.m
@@ -27,8 +27,6 @@
 #import "JNIUtilities.h"
 
 #import <AppKit/AppKit.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 
 static BOOL JavaAccessibilityIsSupportedAttribute(id element, NSString *attribute);
 static void JavaAccessibilityLogError(NSString *message);
@@ -58,7 +56,7 @@ NSSize getAxComponentSize(JNIEnv *env, jobject axComponent, jobject component)
     DECLARE_STATIC_METHOD_RETURN(jm_getSize, sjc_CAccessibility, "getSize",
            "(Ljavax/accessibility/AccessibleComponent;Ljava/awt/Component;)Ljava/awt/Dimension;", NSZeroSize);
 
-    jobject dimension = (*env)->CallStaticObjectMethod(env, jc_Dimension, jm_getSize, axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    jobject dimension = (*env)->CallStaticObjectMethod(env, jc_Dimension, jm_getSize, axComponent, component);
     CHECK_EXCEPTION();
 
     if (dimension == NULL) return NSZeroSize;
@@ -71,11 +69,11 @@ NSString *getJavaRole(JNIEnv *env, jobject axComponent, jobject component)
     DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleRole, sjc_CAccessibility, "getAccessibleRole",
                            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
     jobject axRole = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleRole,
-                      axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                      axComponent, component);
     CHECK_EXCEPTION();
     if (axRole == NULL) return @"unknown";
 
-    NSString* str = JNFJavaToNSString(env, axRole);
+    NSString* str = JavaStringToNSString(env, axRole);
     (*env)->DeleteLocalRef(env, axRole);
     return str;
 }
@@ -86,7 +84,7 @@ jobject getAxSelection(JNIEnv *env, jobject axContext, jobject component)
     DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleSelection, sjc_CAccessibility, "getAccessibleSelection",
             "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleSelection;", nil);
     jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleSelection,
-                      axContext, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                      axContext, component);
     CHECK_EXCEPTION();
     return o;
 }
@@ -97,7 +95,7 @@ jobject getAxContextSelection(JNIEnv *env, jobject axContext, jint index, jobjec
     DECLARE_STATIC_METHOD_RETURN(jm_ax_getAccessibleSelection, sjc_CAccessibility, "ax_getAccessibleSelection",
                   "(Ljavax/accessibility/AccessibleContext;ILjava/awt/Component;)Ljavax/accessibility/Accessible;", nil);
     return (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_ax_getAccessibleSelection,
-                    axContext, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                    axContext, index, component);
     CHECK_EXCEPTION();
 }
 
@@ -107,7 +105,7 @@ void setAxContextSelection(JNIEnv *env, jobject axContext, jint index, jobject c
     DECLARE_STATIC_METHOD(jm_addAccessibleSelection, sjc_CAccessibility, "addAccessibleSelection",
                    "(Ljavax/accessibility/AccessibleContext;ILjava/awt/Component;)V");
     (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_addAccessibleSelection,
-                    axContext, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                    axContext, index, component);
     CHECK_EXCEPTION();
 }
 
@@ -117,7 +115,7 @@ jobject getAxContext(JNIEnv *env, jobject accessible, jobject component)
     DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleContext, sjc_CAccessibility, "getAccessibleContext",
                "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleContext;", nil);
     jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleContext,
-                    accessible, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                    accessible, component);
     CHECK_EXCEPTION();
     return o;
 }
@@ -128,7 +126,7 @@ BOOL isChildSelected(JNIEnv *env, jobject accessible, jint index, jobject compon
     DECLARE_STATIC_METHOD_RETURN(jm_isAccessibleChildSelected, sjc_CAccessibility, "isAccessibleChildSelected",
                 "(Ljavax/accessibility/Accessible;ILjava/awt/Component;)Z", NO);
     jboolean b = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isAccessibleChildSelected,
-                    accessible, index, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                    accessible, index, component);
     CHECK_EXCEPTION();
     return b;
 }
@@ -139,7 +137,7 @@ jobject getAxStateSet(JNIEnv *env, jobject axContext, jobject component)
     DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleStateSet, sjc_CAccessibility, "getAccessibleStateSet",
                "(Ljavax/accessibility/AccessibleContext;Ljava/awt/Component;)Ljavax/accessibility/AccessibleStateSet;", nil);
     jobject o = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleStateSet,
-                    axContext, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                    axContext, component);
     CHECK_EXCEPTION();
     return o;
 }
@@ -149,7 +147,7 @@ BOOL containsAxState(JNIEnv *env, jobject axContext, jobject axState, jobject co
     GET_CACCESSIBILITY_CLASS_RETURN(NO);
     DECLARE_STATIC_METHOD_RETURN(jm_contains, sjc_CAccessibility, "contains",
                "(Ljavax/accessibility/AccessibleContext;Ljavax/accessibility/AccessibleState;Ljava/awt/Component;)Z", NO);
-    jboolean b = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_contains, axContext, axState, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    jboolean b = (*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_contains, axContext, axState, component);
     CHECK_EXCEPTION();
     return b;
 }
@@ -210,7 +208,7 @@ NSPoint getAxComponentLocationOnScreen(JNIEnv *env, jobject axComponent, jobject
     DECLARE_FIELD_RETURN(sjf_X, sjc_Point, "x", "I", NSZeroPoint);
     DECLARE_FIELD_RETURN(sjf_Y, sjc_Point, "y", "I", NSZeroPoint);
     jobject jpoint = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getLocationOnScreen,
-                      axComponent, component); // AWT_THREADING Safe (AWTRunLoopMode)
+                      axComponent, component);
     CHECK_EXCEPTION();
     if (jpoint == NULL) return NSZeroPoint;
     return NSMakePoint((*env)->GetIntField(env, jpoint, sjf_X), (*env)->GetIntField(env, jpoint, sjf_Y));
@@ -221,7 +219,7 @@ jint getAxTextCharCount(JNIEnv *env, jobject axText, jobject component)
     GET_CACCESSIBILITY_CLASS_RETURN(0);
     DECLARE_STATIC_METHOD_RETURN(jm_getCharCount, sjc_CAccessibility, "getCharCount",
                   "(Ljavax/accessibility/AccessibleText;Ljava/awt/Component;)I", 0);
-    int i = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, jm_getCharCount, axText, component); // AWT_THREADING Safe (AWTRunLoopMode)
+    int i = (*env)->CallStaticIntMethod(env, sjc_CAccessibility, jm_getCharCount, axText, component);
     CHECK_EXCEPTION();
     return i;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaComponentAccessibility.m
@@ -35,7 +35,6 @@
 
 #import <AppKit/AppKit.h>
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import <dlfcn.h>
@@ -313,7 +312,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
         NSInteger i;
         for (i = 0; i < count; i++) {
-            jstring jString = JNFNSToJavaString(env, [ignoredKeys objectAtIndex:i]);
+            jstring jString = NSStringToJavaString(env, [ignoredKeys objectAtIndex:i]);
             (*env)->SetObjectArrayElement(env, result, i, jString);
             (*env)->DeleteLocalRef(env, jString);
         }
@@ -349,7 +348,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     if (parent->fAccessible == NULL) return nil;
     GET_CHILDRENANDROLES_METHOD_RETURN(nil);
     jobjectArray jchildrenAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
-                  parent->fAccessible, parent->fComponent, whichChildren, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
+                  parent->fAccessible, parent->fComponent, whichChildren, allowIgnored);
     CHECK_EXCEPTION();
     if (jchildrenAndRoles == NULL) return nil;
 
@@ -369,7 +368,7 @@ static NSObject *sAttributeNamesLOCK = nil;
             DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
             jobject jkey = (*env)->GetObjectField(env, jchildJavaRole, sjf_key);
             CHECK_EXCEPTION();
-            childJavaRole = JNFJavaToNSString(env, jkey);
+            childJavaRole = JavaStringToNSString(env, jkey);
             (*env)->DeleteLocalRef(env, jkey);
         }
 
@@ -486,7 +485,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     // Get all the other accessibility attributes states we need in one swell foop.
     // javaRole isn't pulled in because we need protected access to AccessibleRole.key
     jbooleanArray attributeStates = (jbooleanArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                     jm_getInitialAttributeStates, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                     jm_getInitialAttributeStates, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (attributeStates == NULL) return nil;
     jboolean *attributeStatesArray = (*env)->GetBooleanArrayElements(env, attributeStates, 0);
@@ -585,7 +584,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     // On MacOSX, text doesn't have actions, in java it does.
     // cmcnote: NOT TRUE - Editable text has AXShowMenu. Textfields have AXConfirm. Static text has no actions.
-    jobject axAction = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleAction, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axAction = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getAccessibleAction, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axAction != NULL) {
         //+++gdb NOTE: In MacOSX, there is just a single Action, not multiple. In java,
@@ -862,7 +861,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     GET_CACCESSIBILITY_CLASS_RETURN(nil);
     DECLARE_STATIC_METHOD_RETURN(jm_isEnabled, sjc_CAccessibility, "isEnabled", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Z", nil);
 
-    NSNumber *value = [NSNumber numberWithBool:(*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isEnabled, fAccessible, fComponent)]; // AWT_THREADING Safe (AWTRunLoop)
+    NSNumber *value = [NSNumber numberWithBool:(*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, jm_isEnabled, fAccessible, fComponent)];
     CHECK_EXCEPTION();
     if (value == nil) {
         NSLog(@"WARNING: %s called on component that has no accessible component: %@", __FUNCTION__, self);
@@ -894,7 +893,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     // as well as having AccessibleState.FOCUSABLE in its AccessibleStateSet.
     // We use the former heuristic; if the component focus-traversable, add a focused attribute
     // See also initializeAttributeNamesWithEnv:
-    if ((*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, sjm_isFocusTraversable, fAccessible, fComponent)) { // AWT_THREADING Safe (AWTRunLoop)
+    if ((*env)->CallStaticBooleanMethod(env, sjc_CAccessibility, sjm_isFocusTraversable, fAccessible, fComponent)) {
         return YES;
     }
     CHECK_EXCEPTION();
@@ -911,7 +910,7 @@ static NSObject *sAttributeNamesLOCK = nil;
 
     if ([(NSNumber*)value boolValue])
     {
-        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestFocus, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestFocus, fAccessible, fComponent);
         CHECK_EXCEPTION();
     }
 }
@@ -925,12 +924,12 @@ static NSObject *sAttributeNamesLOCK = nil;
     DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleDescription, sjc_CAccessibility, "getAccessibleDescription",
                                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
     jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                                   sjm_getAccessibleDescription, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                                   sjm_getAccessibleDescription, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (val == NULL) {
         return nil;
     }
-    NSString* str = JNFJavaToNSString(env, val);
+    NSString* str = JavaStringToNSString(env, val);
     (*env)->DeleteLocalRef(env, val);
     return str;
 }
@@ -952,6 +951,32 @@ static NSObject *sAttributeNamesLOCK = nil;
     return NO;
 }
 
+/*
+ * The java/lang/Number concrete class could be for any of the Java primitive
+ * numerical types or some other subclass.
+ * All existing A11Y code uses Integer so that is what we look for first
+ * But all must be able to return a double and NSNumber accepts a double,
+ * so that's the fall back.
+ */
+static NSNumber* JavaNumberToNSNumber(JNIEnv *env, jobject jnumber) {
+    if (jnumber == NULL) {
+        return nil;
+    }
+    DECLARE_CLASS_RETURN(jnumber_Class, "java/lang/Number", nil);
+    DECLARE_CLASS_RETURN(jinteger_Class, "java/lang/Integer", nil);
+    DECLARE_METHOD_RETURN(jm_intValue, jnumber_Class, "intValue", "()D", nil);
+    DECLARE_METHOD_RETURN(jm_doubleValue, jnumber_Class, "doubleValue", "()D", nil);
+    if ((*env)->IsInstanceOf(env, jnumber, jinteger_Class)) {
+        jint i = (*env)->CallIntMethod(env, jnumber_Class, jm_intValue);
+        CHECK_EXCEPTION();
+        return [NSNumber numberWithInteger:i];
+    } else {
+        jdouble d = (*env)->CallDoubleMethod(env, jnumber_Class, jm_doubleValue);
+        CHECK_EXCEPTION();
+        return [NSNumber numberWithDouble:d];
+    }
+}
+
 // Element's maximum value (id)
 - (id)accessibilityMaxValueAttribute
 {
@@ -960,12 +985,12 @@ static NSObject *sAttributeNamesLOCK = nil;
     DECLARE_STATIC_METHOD_RETURN(jm_getMaximumAccessibleValue, sjc_CAccessibility, "getMaximumAccessibleValue",
                                   "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
 
-    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMaximumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMaximumAccessibleValue, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axValue == NULL) {
         return [NSNumber numberWithInt:0];
     }
-    NSNumber* num = JNFJavaToNSNumber(env, axValue);
+    NSNumber* num = JavaNumberToNSNumber(env, axValue);
     (*env)->DeleteLocalRef(env, axValue);
     return num;
 }
@@ -983,12 +1008,12 @@ static NSObject *sAttributeNamesLOCK = nil;
     DECLARE_STATIC_METHOD_RETURN(jm_getMinimumAccessibleValue, sjc_CAccessibility, "getMinimumAccessibleValue",
                                   "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/Number;", nil);
 
-    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMinimumAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getMinimumAccessibleValue, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axValue == NULL) {
         return [NSNumber numberWithInt:0];
     }
-    NSNumber* num = JNFJavaToNSNumber(env, axValue);
+    NSNumber* num = JavaNumberToNSNumber(env, axValue);
     (*env)->DeleteLocalRef(env, axValue);
     return num;
 }
@@ -1040,7 +1065,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     JNIEnv* env = [ThreadUtilities getJNIEnv];
     GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(nil);
     jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleComponent,
-                           fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                           fAccessible, fComponent);
     CHECK_EXCEPTION();
 
     // NSAccessibility wants the bottom left point of the object in
@@ -1111,7 +1136,7 @@ static NSObject *sAttributeNamesLOCK = nil;
         jobject axRole = (*env)->CallStaticObjectMethod(env, jm_getAccessibleRoleDisplayString, fAccessible, fComponent);
         CHECK_EXCEPTION();
         if (axRole != NULL) {
-            value = JNFJavaToNSString(env, axRole);
+            value = JavaStringToNSString(env, axRole);
             (*env)->DeleteLocalRef(env, axRole);
         } else {
             value = @"unknown";
@@ -1167,7 +1192,7 @@ static NSObject *sAttributeNamesLOCK = nil;
                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)V");
 
     if ([(NSNumber*)value boolValue]) {
-        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestSelection, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+        (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_requestSelection, fAccessible, fComponent);
         CHECK_EXCEPTION();
     }
 }
@@ -1177,7 +1202,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     JNIEnv* env = [ThreadUtilities getJNIEnv];
     GET_ACCESSIBLECOMPONENT_STATIC_METHOD_RETURN(nil);
     jobject axComponent = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                           sjm_getAccessibleComponent, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                           sjm_getAccessibleComponent, fAccessible, fComponent);
     CHECK_EXCEPTION();
     NSValue* size = [NSValue valueWithSize:getAxComponentSize(env, axComponent, fComponent)];
     (*env)->DeleteLocalRef(env, axComponent);
@@ -1239,12 +1264,12 @@ static NSObject *sAttributeNamesLOCK = nil;
     JNIEnv* env = [ThreadUtilities getJNIEnv];
 
     GET_ACCESSIBLENAME_METHOD_RETURN(nil);
-    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject val = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleName, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (val == NULL) {
         return nil;
     }
-    NSString* str = JNFJavaToNSString(env, val);
+    NSString* str = JavaStringToNSString(env, val);
     (*env)->DeleteLocalRef(env, val);
     return str;
 }
@@ -1300,12 +1325,12 @@ static NSObject *sAttributeNamesLOCK = nil;
                         (*env)->CallStaticObjectMethod( env,
                                                    sjm_getAccessibleName,
                                                    selectedMenuItem->fAccessible,
-                                                   selectedMenuItem->fComponent ); // AWT_THREADING Safe (AWTRunLoop)
+                                                   selectedMenuItem->fComponent );
                 CHECK_EXCEPTION();
                 if (itemValue == NULL) {
                     return nil;
                 }
-                NSString* itemString = JNFJavaToNSString(env, itemValue);
+                NSString* itemString = JavaStringToNSString(env, itemValue);
                 (*env)->DeleteLocalRef(env, itemValue);
                 return itemString;
             } else {
@@ -1322,7 +1347,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     GET_CACCESSIBILITY_CLASS_RETURN(nil);
     DECLARE_STATIC_METHOD_RETURN(sjm_getAccessibleValue, sjc_CAccessibility, "getAccessibleValue",
                 "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljavax/accessibility/AccessibleValue;", nil);
-    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleValue, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject axValue = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, sjm_getAccessibleValue, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axValue != NULL) {
         DECLARE_STATIC_METHOD_RETURN(jm_getCurrentAccessibleValue, sjc_CAccessibility, "getCurrentAccessibleValue",
@@ -1330,7 +1355,7 @@ static NSObject *sAttributeNamesLOCK = nil;
         jobject str = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getCurrentAccessibleValue, axValue, fComponent);
         CHECK_EXCEPTION();
         if (str != NULL) {
-            num = JNFJavaToNSNumber(env, str); // AWT_THREADING Safe (AWTRunLoop)
+            num = JavaNumberToNSNumber(env, str);
             (*env)->DeleteLocalRef(env, str);
         }
         (*env)->DeleteLocalRef(env, axValue);
@@ -1436,9 +1461,9 @@ static NSObject *sAttributeNamesLOCK = nil;
     jobject jparent = fComponent;
 
     id value = nil;
-    if (JNFIsInstanceOf(env, jparent, &jc_Container)) {
+    if ((*env)->IsInstanceOf(env, jparent, jc_Container)) {
         jobject jaccessible = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_accessibilityHitTest,
-                               jparent, (jfloat)point.x, (jfloat)point.y); // AWT_THREADING Safe (AWTRunLoop)
+                               jparent, (jfloat)point.x, (jfloat)point.y);
         CHECK_EXCEPTION();
         if (jaccessible != NULL) {
             value = [JavaComponentAccessibility createWithAccessible:jaccessible withEnv:env withView:fView];
@@ -1468,7 +1493,7 @@ static NSObject *sAttributeNamesLOCK = nil;
     id value = nil;
 
     NSWindow* hostWindow = [[self->fView window] retain];
-    jobject focused = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getFocusOwner, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+    jobject focused = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getFocusOwner, fComponent);
     [hostWindow release];
     CHECK_EXCEPTION();
 
@@ -1670,7 +1695,7 @@ JNI_COCOA_EXIT(env);
 {
     GET_CHILDRENANDROLES_METHOD_RETURN(nil);
     jobjectArray jtabsAndRoles = (jobjectArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibility, jm_getChildrenAndRoles,
-                                  fAccessible, fComponent, whichTabs, allowIgnored); // AWT_THREADING Safe (AWTRunLoop)
+                                  fAccessible, fComponent, whichTabs, allowIgnored);
     CHECK_EXCEPTION();
     if(jtabsAndRoles == NULL) return nil;
 
@@ -1691,7 +1716,7 @@ JNI_COCOA_EXIT(env);
     DECLARE_FIELD_RETURN(sjf_key, sjc_AccessibleRole, "key", "Ljava/lang/String;", nil);
     jobject jkey = (*env)->GetObjectField(env, jtabJavaRole, sjf_key);
     CHECK_EXCEPTION();
-    NSString *tabJavaRole = JNFJavaToNSString(env, jkey);
+    NSString *tabJavaRole = JavaStringToNSString(env, jkey);
     (*env)->DeleteLocalRef(env, jkey);
 
     NSInteger i;
@@ -2046,11 +2071,11 @@ static BOOL ObjectEquals(JNIEnv *env, jobject a, jobject b, jobject component)
         DECLARE_CLASS_RETURN(sjc_LWCToolkit, "sun/lwawt/macosx/LWCToolkit", NO);
         DECLARE_STATIC_METHOD_RETURN(jm_doEquals, sjc_LWCToolkit, "doEquals",
                                      "(Ljava/lang/Object;Ljava/lang/Object;Ljava/awt/Component;)Z", NO);
-        return (*env)->CallStaticBooleanMethod(env, sjc_LWCToolkit, jm_doEquals, a, b, component); // AWT_THREADING Safe (AWTRunLoopMode)
+        return (*env)->CallStaticBooleanMethod(env, sjc_LWCToolkit, jm_doEquals, a, b, component);
         CHECK_EXCEPTION();
     }
 
-    jboolean jb = (*env)->CallBooleanMethod(env, a, jm_equals, b); // AWT_THREADING Safe (!appKit)
+    jboolean jb = (*env)->CallBooleanMethod(env, a, jm_equals, b);
     CHECK_EXCEPTION();
     return jb;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaTextAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaTextAccessibility.m
@@ -134,10 +134,10 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     if ([[self accessibilityRoleAttribute] isEqualToString:NSAccessibilityStaticTextRole]) {
         // if it's static text, the AppKit AXValue is the java accessibleName
         jobject axName = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                           sjm_getAccessibleName, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                           sjm_getAccessibleName, fAccessible, fComponent);
         CHECK_EXCEPTION();
         if (axName != NULL) {
-            NSString* str = JNFJavaToNSString(env, axName);
+            NSString* str = JavaStringToNSString(env, axName);
             (*env)->DeleteLocalRef(env, axName);
             return str;
         }
@@ -147,14 +147,14 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     // cmcnote: inefficient to make three distinct JNI calls. Coalesce. radr://3951923
     GET_ACCESSIBLETEXT_METHOD_RETURN(@"");
     jobject axText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                      sjm_getAccessibleText, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                      sjm_getAccessibleText, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axText == NULL) return nil;
     (*env)->DeleteLocalRef(env, axText);
 
     GET_ACCESSIBLEEDITABLETEXT_METHOD_RETURN(nil);
     jobject axEditableText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
-                       sjm_getAccessibleEditableText, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                       sjm_getAccessibleEditableText, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axEditableText == NULL) return nil;
 
@@ -163,7 +163,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     jobject jrange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getTextRange,
                        axEditableText, 0, getAxTextCharCount(env, axEditableText, fComponent), fComponent);
     CHECK_EXCEPTION();
-    NSString *string = JNFJavaToNSString(env, jrange); // AWT_THREADING Safe (AWTRunLoop)
+    NSString *string = JavaStringToNSString(env, jrange);
 
     (*env)->DeleteLocalRef(env, jrange);
     (*env)->DeleteLocalRef(env, axEditableText);
@@ -181,7 +181,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
     GET_ACCESSIBLEEDITABLETEXT_METHOD_RETURN(NO);
     jobject axEditableText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
-                     sjm_getAccessibleEditableText, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                     sjm_getAccessibleEditableText, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axEditableText == NULL) return NO;
     (*env)->DeleteLocalRef(env, axEditableText);
@@ -204,10 +204,10 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getSelectedText, sjc_CAccessibleText, "getSelectedText",
               "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)Ljava/lang/String;", nil);
     jobject axText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getSelectedText,
-                        fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                        fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axText == NULL) return @"";
-    NSString* str = JNFJavaToNSString(env, axText);
+    NSString* str = JavaStringToNSString(env, axText);
     (*env)->DeleteLocalRef(env, axText);
     return str;
 }
@@ -227,12 +227,12 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
 #endif
 
     JNIEnv *env = [ThreadUtilities getJNIEnv];
-    jstring jstringValue = JNFNSToJavaString(env, (NSString *)value);
+    jstring jstringValue = NSStringToJavaString(env, (NSString *)value);
     GET_CACCESSIBLETEXT_CLASS();
     DECLARE_STATIC_METHOD(jm_setSelectedText, sjc_CAccessibleText, "setSelectedText",
                    "(Ljavax/accessibility/Accessible;Ljava/awt/Component;Ljava/lang/String;)V");
     (*env)->CallStaticVoidMethod(env, sjc_CAccessibleText, jm_setSelectedText,
-              fAccessible, fComponent, jstringValue); // AWT_THREADING Safe (AWTRunLoop)
+              fAccessible, fComponent, jstringValue);
     CHECK_EXCEPTION();
 }
 
@@ -244,7 +244,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getSelectedTextRange, sjc_CAccessibleText, "getSelectedTextRange",
            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[I", nil);
     jintArray axTextRange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
-                jm_getSelectedTextRange, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                jm_getSelectedTextRange, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axTextRange == NULL) return nil;
 
@@ -274,7 +274,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD(jm_setSelectedTextRange, sjc_CAccessibleText, "setSelectedTextRange",
                   "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)V");
     (*env)->CallStaticVoidMethod(env, sjc_CAccessibleText, jm_setSelectedTextRange,
-                  fAccessible, fComponent, startIndex, endIndex); // AWT_THREADING Safe (AWTRunLoop)
+                  fAccessible, fComponent, startIndex, endIndex);
     CHECK_EXCEPTION();
 }
 
@@ -285,7 +285,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     GET_ACCESSIBLETEXT_METHOD_RETURN(nil);
     jobject axText = (*env)->CallStaticObjectMethod(env, sjc_CAccessibility,
-                     sjm_getAccessibleText, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                     sjm_getAccessibleText, fAccessible, fComponent);
     CHECK_EXCEPTION();
     NSNumber* num = [NSNumber numberWithInt:getAxTextCharCount(env, axText, fComponent)];
     (*env)->DeleteLocalRef(env, axText);
@@ -304,7 +304,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getVisibleCharacterRange, sjc_CAccessibleText, "getVisibleCharacterRange",
                           "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)[I", nil);
     jintArray axTextRange = (*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
-                 jm_getVisibleCharacterRange, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                 jm_getVisibleCharacterRange, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (axTextRange == NULL) return nil;
 
@@ -326,7 +326,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getLineNumberForInsertionPoint, sjc_CAccessibleText,
              "getLineNumberForInsertionPoint", "(Ljavax/accessibility/Accessible;Ljava/awt/Component;)I", nil);
     jint row = (*env)->CallStaticIntMethod(env, sjc_CAccessibleText,
-                  jm_getLineNumberForInsertionPoint, fAccessible, fComponent); // AWT_THREADING Safe (AWTRunLoop)
+                  jm_getLineNumberForInsertionPoint, fAccessible, fComponent);
     CHECK_EXCEPTION();
     if (row < 0) return nil;
     return [NSNumber numberWithInt:row];
@@ -365,7 +365,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getBoundsForRange, sjc_CAccessibleText, "getBoundsForRange",
                          "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)[D", nil);
     jdoubleArray axBounds = (jdoubleArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getBoundsForRange,
-                              fAccessible, fComponent, range.location, range.length); // AWT_THREADING Safe (AWTRunLoop)
+                              fAccessible, fComponent, range.location, range.length);
     CHECK_EXCEPTION();
     if (axBounds == NULL) return nil;
 
@@ -397,7 +397,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getLineNumberForIndex, sjc_CAccessibleText, "getLineNumberForIndex",
                            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)I", nil);
     jint row = (*env)->CallStaticIntMethod(env, sjc_CAccessibleText, jm_getLineNumberForIndex,
-                       fAccessible, fComponent, [line intValue]); // AWT_THREADING Safe (AWTRunLoop)
+                       fAccessible, fComponent, [line intValue]);
     CHECK_EXCEPTION();
     if (row < 0) return nil;
     return [NSNumber numberWithInt:row];
@@ -413,7 +413,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getRangeForLine, sjc_CAccessibleText, "getRangeForLine",
                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)[I", nil);
     jintArray axTextRange = (jintArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText,
-                jm_getRangeForLine, fAccessible, fComponent, [line intValue]); // AWT_THREADING Safe (AWTRunLoop)
+                jm_getRangeForLine, fAccessible, fComponent, [line intValue]);
     CHECK_EXCEPTION();
     if (axTextRange == NULL) return nil;
 
@@ -443,10 +443,10 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getStringForRange, sjc_CAccessibleText, "getStringForRange",
                  "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)Ljava/lang/String;", nil);
     jstring jstringForRange = (jstring)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getStringForRange,
-                            fAccessible, fComponent, range.location, range.length); // AWT_THREADING Safe (AWTRunLoop)
+                            fAccessible, fComponent, range.location, range.length);
     CHECK_EXCEPTION();
     if (jstringForRange == NULL) return @"";
-    NSString* str = JNFJavaToNSString(env, jstringForRange);
+    NSString* str = JavaStringToNSString(env, jstringForRange);
     (*env)->DeleteLocalRef(env, jstringForRange);
     return str;
 }
@@ -475,7 +475,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getCharacterIndexAtPosition, sjc_CAccessibleText, "getCharacterIndexAtPosition",
                            "(Ljavax/accessibility/Accessible;Ljava/awt/Component;II)I", nil);
     jint charIndex = (*env)->CallStaticIntMethod(env, sjc_CAccessibleText, jm_getCharacterIndexAtPosition,
-                            fAccessible, fComponent, point.x, point.y); // AWT_THREADING Safe (AWTRunLoop)
+                            fAccessible, fComponent, point.x, point.y);
     CHECK_EXCEPTION();
     if (charIndex == -1) return nil;
 
@@ -508,7 +508,7 @@ NSValue *javaIntArrayToNSRangeValue(JNIEnv* env, jintArray array) {
     DECLARE_STATIC_METHOD_RETURN(jm_getRangeForIndex, sjc_CAccessibleText, "getRangeForIndex",
                     "(Ljavax/accessibility/Accessible;Ljava/awt/Component;I)[I", nil);
     jintArray axTextRange = (jintArray)(*env)->CallStaticObjectMethod(env, sjc_CAccessibleText, jm_getRangeForIndex,
-                              fAccessible, fComponent, index); // AWT_THREADING Safe (AWTRunLoop)
+                              fAccessible, fComponent, index);
     CHECK_EXCEPTION();
     if (axTextRange == NULL) return nil;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -456,7 +456,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_LWCToolkit_nativeSyncQueue
         // could happen if we are embedded inside SWT application,
         // in this case just spin a single empty block through
         // the event loop to give it a chance to process pending events
-        [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){}];
+        [ThreadUtilities performOnMainThreadWaiting:YES block:^(){}];
     }
 
     if (([AWTToolkit getEventCount] - currentEventNum) != 0) {
@@ -517,7 +517,7 @@ BOOL doLoadNativeColors(JNIEnv *env, jintArray jColors, BOOL useAppleColors) {
     UInt32 colorsArray[len];
     UInt32 *colors = colorsArray;
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         NSUInteger i;
         for (i = 0; i < len; i++) {
             colors[i] = RGB([CSystemColors getColor:i useAppleColor:useAppleColors]);
@@ -587,7 +587,7 @@ JNI_COCOA_ENTER(env);
     // Don't use acceptInputForMode because that doesn't setup autorelease pools properly
     BOOL isRunning = true;
     while (![mediatorObject shouldEndRunLoop] && isRunning) {
-        isRunning = [[NSRunLoop currentRunLoop] runMode:(inAWT ? [JNFRunLoop javaRunLoopMode] : NSDefaultRunLoopMode)
+        isRunning = [[NSRunLoop currentRunLoop] runMode:(inAWT ? [ThreadUtilities javaRunLoopMode] : NSDefaultRunLoopMode)
                                              beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.010]];
         if (processEvents) {
             //We do not spin a runloop here as date is nil, so does not matter which mode to use
@@ -654,7 +654,7 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_LWCToolkit_isCapsLockOn
 (JNIEnv *env, jobject self)
 {
     __block jboolean isOn = JNI_FALSE;
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         NSUInteger modifiers = [NSEvent modifierFlags];
         isOn = (modifiers & NSAlphaShiftKeyMask) != 0;
     }];
@@ -727,7 +727,7 @@ JNIEXPORT jstring JNICALL
 Java_sun_font_FontManager_getFontPath
 (JNIEnv *env, jclass obj, jboolean noType1)
 {
-    return JNFNSToJavaString(env, @"/Library/Fonts");
+    return NSStringToJavaString(env, @"/Library/Fonts");
 }
 
 // This isn't yet used on unix, the implementation is added since shared
@@ -869,7 +869,7 @@ JNIEXPORT jint JNICALL
 Java_sun_lwawt_macosx_LWCToolkit_getMultiClickTime(JNIEnv *env, jclass klass) {
     __block jint multiClickTime = 0;
     JNI_COCOA_ENTER(env);
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         multiClickTime = (jint)([NSEvent doubleClickInterval] * 1000);
     }];
     JNI_COCOA_EXIT(env);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrintModel.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrintModel.m
@@ -26,8 +26,6 @@
 
 #import "PrintModel.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #import "PrinterView.h"
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
@@ -53,7 +51,7 @@
 - (BOOL)runPageSetup {
     __block BOOL fResult = NO;
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         NSPageLayout* pageLayout = [NSPageLayout pageLayout];
         fResult = ([pageLayout runModalWithPrintInfo:fPrintInfo] == NSOKButton);
     }];
@@ -64,7 +62,7 @@
 - (BOOL)runJobSetup {
     __block BOOL fResult = NO;
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         NSPrintPanel* printPanel = [NSPrintPanel printPanel];
         fResult = ([printPanel runModalWithPrintInfo:fPrintInfo] == NSOKButton);
     }];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterSurfaceData.m
@@ -26,8 +26,6 @@
 
 #import "PrinterSurfaceData.h"
 #import "jni_util.h"
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 
 //#define DEBUG 1
 #if defined DEBUG

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -28,8 +28,6 @@
 #import "java_awt_print_Pageable.h"
 #import "java_awt_print_PageFormat.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #import "ThreadUtilities.h"
 #import "GeomUtilities.h"
 #import "JNIUtilities.h"
@@ -106,7 +104,7 @@ static jclass sjc_CPrinterJob = NULL;
     CGContextSaveGState(cgRef); //04/28/2004: state needs to be saved here due to addition of lazy state management
 
     (*env)->CallVoidMethod(env, fPrinterJob, jm_printToPathGraphics, fCurPeekGraphics, fPrinterJob,
-                           fCurPainter, fCurPageFormat, jPageIndex, context); // AWT_THREADING Safe (AWTRunLoop)
+                           fCurPainter, fCurPageFormat, jPageIndex, context);
     CHECK_EXCEPTION();
 
     CGContextRestoreGState(cgRef);
@@ -122,9 +120,9 @@ static jclass sjc_CPrinterJob = NULL;
     GET_CPRINTERJOB_CLASS_RETURN(nil);
     DECLARE_METHOD_RETURN(jm_getJobName, sjc_CPrinterJob, "getJobName", "()Ljava/lang/String;", nil);
 
-    jobject o = (*env)->CallObjectMethod(env, fPrinterJob, jm_getJobName); // AWT_THREADING Safe (known object)
+    jobject o = (*env)->CallObjectMethod(env, fPrinterJob, jm_getJobName);
     CHECK_EXCEPTION();
-    id result = JNFJavaToNSString(env, o);
+    id result = JavaStringToNSString(env, o);
     (*env)->DeleteLocalRef(env, o);
     return result;
 }
@@ -195,7 +193,7 @@ static jclass sjc_CPrinterJob = NULL;
     }
 
     jobjectArray objectArray = (*env)->CallObjectMethod(env, fPrinterJob,
-                                jm_getPageformatPrintablePeekgraphics, jPageNumber); // AWT_THREADING Safe (AWTRunLoopMode)
+                                jm_getPageformatPrintablePeekgraphics, jPageNumber);
     CHECK_EXCEPTION();
     if (objectArray != NULL) {
         // Get references to the return objects -> PageFormat, Printable, PeekGraphics
@@ -214,7 +212,7 @@ static jclass sjc_CPrinterJob = NULL;
 
         // Actually print and get the PageFormatArea
         jobject pageFormatArea = (*env)->CallObjectMethod(env, fPrinterJob, jm_printAndGetPageFormatArea, fCurPainter,
-                                    fCurPeekGraphics, fCurPageFormat, jPageNumber); // AWT_THREADING Safe (AWTRunLoopMode)
+                                    fCurPeekGraphics, fCurPageFormat, jPageNumber);
         CHECK_EXCEPTION();
         if (pageFormatArea != NULL) {
             NSPrintingOrientation currentOrientation =

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzRenderer.m
@@ -28,7 +28,6 @@
 #import "sun_java2d_OSXSurfaceData.h"
 
 #import <stdio.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "ImageSurfaceData.h"
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/QuartzSurfaceData.m
@@ -35,8 +35,6 @@
 #import "sun_lwawt_macosx_CPrinterSurfaceData.h"
 #import "ImageSurfaceData.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #import <AppKit/AppKit.h>
 #import "ThreadUtilities.h"
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTFont.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #import "java_awt_Font.h"
 #import "sun_awt_PlatformFont.h"
 #import "sun_awt_FontDescriptor.h"
@@ -310,9 +308,9 @@ JNI_COCOA_ENTER(env);
     jint i;
     for (i = 0; i < num; i++) {
         NSString *fontname = [filteredFonts objectAtIndex:i];
-        jobject jFontName = JNFNSToJavaString(env, fontname);
+        jobject jFontName = NSStringToJavaString(env, fontname);
         jobject jFontFamilyName =
-            JNFNSToJavaString(env, GetFamilyNameForFontName(fontname));
+            NSStringToJavaString(env, GetFamilyNameForFontName(fontname));
 
         (*env)->CallVoidMethod(env, jthis, jm_registerFont, jFontName, jFontFamilyName);
         CHECK_EXCEPTION();
@@ -334,7 +332,7 @@ Java_sun_font_CFontManager_loadNativeDirFonts
 {
 JNI_COCOA_ENTER(env);
 
-    NSString *path = JNFJavaToNSString(env, filename);
+    NSString *path = JavaStringToNSString(env, filename);
     NSURL *url = [NSURL fileURLWithPath:(NSString *)path];
     bool res = CTFontManagerRegisterFontsForURL((CFURLRef)url, kCTFontManagerScopeProcess, nil);
 #ifdef DEBUG
@@ -434,7 +432,7 @@ Java_sun_font_CFont_createNativeFont
 JNI_COCOA_ENTER(env);
 
     awtFont =
-        [AWTFont awtFontForName:JNFJavaToNSString(env, nativeFontName)
+        [AWTFont awtFontForName:JavaStringToNSString(env, nativeFontName)
          style:style]; // autoreleased
 
     if (awtFont) {
@@ -570,7 +568,7 @@ Java_sun_font_CFont_getCascadeList
 #ifdef DEBUG
         NSLog(@"Font is : %@", (NSString*)fontname);
 #endif
-        jstring jFontName = (jstring)JNFNSToJavaString(env, fontname);
+        jstring jFontName = (jstring)NSStringToJavaString(env, fontname);
         (*env)->CallBooleanMethod(env, arrayListOfString, addMID, jFontName);
         if ((*env)->ExceptionOccurred(env)) {
             return;

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
@@ -23,7 +23,6 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import "java_awt_geom_PathIterator.h"
 #import "sun_font_CStrike.h"
 #import "sun_font_CStrikeDisposer.h"

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/CCharToGlyphMapper.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/CCharToGlyphMapper.m
@@ -25,8 +25,6 @@
 
 #import "JNIUtilities.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 #import "AWTFont.h"
 #import "CoreTextSupport.h"
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/CGGlyphImages.m
@@ -24,8 +24,8 @@
  */
 
 #import <Accelerate/Accelerate.h> // for vImage_Buffer
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
+#import "JNIUtilities.h"
 #import "CGGlyphImages.h"
 #import "CoreTextSupport.h"
 #import "fontscalerdefs.h" // contains the definition of GlyphInfo struct

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLGraphicsConfig.m
@@ -33,7 +33,6 @@
 #import <stdlib.h>
 #import <string.h>
 #import <ApplicationServices/ApplicationServices.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 /**
  * Disposes all memory and resources associated with the given
@@ -123,6 +122,7 @@ Java_sun_java2d_opengl_CGLGraphicsConfig_getCGLConfigInfo
     __block jlong ret = 0L;
     JNI_COCOA_ENTER(env);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
+
         JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
 
         J2dRlsTraceLn(J2D_TRACE_INFO, "CGLGraphicsConfig_getCGLConfigInfo");
@@ -288,6 +288,7 @@ Java_sun_java2d_opengl_CGLGraphicsConfig_getCGLConfigInfo
         [NSOpenGLContext clearCurrentContext];
         ret = ptr_to_jlong(cglinfo);
         [pool drain];
+
     }];
     JNI_COCOA_EXIT(env);
     return ret;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLLayer.h
@@ -26,8 +26,6 @@
 #ifndef CGLLayer_h_Included
 #define CGLLayer_h_Included
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-
 @interface CGLLayer : CAOpenGLLayer
 {
 @private

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/opengl/CGLSurfaceData.m
@@ -315,7 +315,7 @@ OGLSD_Flush(JNIEnv *env)
         CGLSDOps *dstCGLOps = (CGLSDOps *)dstOps->privOps;
         CGLLayer *layer = (CGLLayer*)dstCGLOps->layer;
         if (layer != NULL) {
-            [JNFRunLoop performOnMainThreadWaiting:NO withBlock:^(){
+            [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
                 AWT_ASSERT_APPKIT_THREAD;
                 [layer setNeedsDisplay];
             }];

--- a/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/JNIUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,5 +236,15 @@
  @finally { \
     [pool drain]; \
  };
+
+/********        STRING CONVERSION SUPPORT    *********/
+
+JNIEXPORT NSString* JavaStringToNSString(JNIEnv *env, jstring jstr);
+
+JNIEXPORT jstring NSStringToJavaString(JNIEnv* env, NSString *str);
+
+JNIEXPORT NSString* NormalizedPathNSStringFromJavaString(JNIEnv *env, jstring pathStr);
+
+JNIEXPORT jstring NormalizedPathJavaStringFromNSString(JNIEnv* env, NSString *str);
 
 #endif /* __JNIUTILITIES_H */

--- a/src/java.desktop/macosx/native/libosxapp/JNIUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/JNIUtilities.m
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "JNIUtilities.h"
+
+NSString* JavaStringToNSString(JNIEnv *env, jstring jstr) {
+    if (jstr == NULL) {
+        return NULL;
+    }
+    jsize len = (*env)->GetStringLength(env, jstr);
+    const jchar *chars = (*env)->GetStringChars(env, jstr, NULL);
+    if (chars == NULL) {
+        return NULL;
+    }
+    NSString *result = [NSString stringWithCharacters:(UniChar *)chars length:len];
+    (*env)->ReleaseStringChars(env, jstr, chars);
+    return result;
+}
+
+jstring NSStringToJavaString(JNIEnv* env, NSString *str) {
+
+    if (str == NULL) {
+       return NULL;
+    }
+    jstring jStr = (*env)->NewStringUTF(env, [str UTF8String]);
+    CHECK_EXCEPTION();
+    return jStr;
+}
+
+/*
+ * These next conversion functions are for file system paths.
+ * The NSString needs to be in de-composed UTF-16 format for the Apple file system
+ * The Java String needs to be in pre-composed UTF-16 format for display by Java.
+ * https://developer.apple.com/library/archive/qa/qa1235/_index.html
+ * has some information on this.
+ */
+
+/*
+ * Returns an NSString in decomposed UTF16 format that is compatible with HFS's
+ * expectation of the UTF16 format for file system paths.
+ *
+ * Example string: "/Users/Amélie/"
+ *
+ * Java's UTF16 string is "/ U s e r s / A m \351 l i e /"
+ * macOS UTF16 string suitable for HFS is "/ U s e r s / A m e \314 \201 l i e /"
+ *
+ * There is no direct API that takes in NSString UTF16 encoded by Java
+ * and produces NSString UTF16 for HFS, so we first need to decompose it
+ * into chars (suitable for low level C file APIs), and only then
+ * create NSString representation of this decomposition back into UTF16 string.
+ *
+ * https://developer.apple.com/documentation/foundation/nsstring/1414559-filesystemrepresentation?language=objc
+ * describes how to get a file system representation as a char* from an NSString
+ * and then using FileManager (!) convert it to an NSString.
+ * But we want an NSString.
+ * So the steps are
+ * 1) Convert to NSString
+ * 2) call [NSString fileSystemRepresentation] which gives us a char*
+ * 3) Convert the returned char* to an NSString using FileManager (is there a better way?)
+ */
+NSString* NormalizedPathNSStringFromJavaString(JNIEnv *env, jstring pathStr) {
+    if (pathStr == NULL) {
+        return nil;
+    }
+    NSString *nsStr = JavaStringToNSString(env, pathStr);
+    if (nsStr == NULL) {
+        return nil;
+    }
+    const char* chs = [nsStr fileSystemRepresentation];
+    int len = strlen(chs);
+    NSString* result = [[NSFileManager defaultManager]
+                  stringWithFileSystemRepresentation:chs length:len];
+    return result;
+}
+
+/*
+ * Given what is (potentially) a de-composed NSString, convert it to pre-composed
+ * Then convert it into a Java String.
+ */
+jstring NormalizedPathJavaStringFromNSString(JNIEnv* env, NSString *str) {
+    if (str == nil) {
+        return NULL;
+    }
+    NSString *normStr = [str precomposedStringWithCanonicalMapping];
+    return NSStringToJavaString(env, normStr);
+}

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.h
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.h
@@ -23,14 +23,8 @@
  * questions.
  */
 
-/*
- * Must include this before JavaNativeFoundation.h to get jni.h from build
- */
-#include "jni.h"
-#include "jni_util.h"
-
+#import "JNIUtilities.h"
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 JNIEXPORT @interface NSApplicationAWT : NSApplication <NSUserNotificationCenterDelegate> {
     NSString *fApplicationName;

--- a/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
+++ b/src/java.desktop/macosx/native/libosxapp/NSApplicationAWT.m
@@ -160,9 +160,6 @@ AWT_ASSERT_APPKIT_THREAD;
     [super finishLaunching];
 
     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
-
-    // inform any interested parties that the AWT has arrived and is pumping
-    [[NSNotificationCenter defaultCenter] postNotificationName:JNFRunLoopDidStartNotification object:self];
 }
 
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
@@ -271,7 +268,7 @@ AWT_ASSERT_APPKIT_THREAD;
 // HACK BEGIN
     // The following is necessary to make the java process behave like a
     // proper foreground application...
-    [JNFRunLoop performOnMainThreadWaiting:NO withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         ProcessSerialNumber psn;
         GetCurrentProcess(&psn);
         TransformProcessType(&psn, kProcessTransformToForegroundApplication);
@@ -326,8 +323,8 @@ AWT_ASSERT_APPKIT_THREAD;
 + (void) runAWTLoopWithApp:(NSApplication*)app {
     NSAutoreleasePool *pool = [NSAutoreleasePool new];
 
-    // Make sure that when we run in AWTRunLoopMode we don't exit randomly
-    [[NSRunLoop currentRunLoop] addPort:[NSPort port] forMode:[JNFRunLoop javaRunLoopMode]];
+    // Make sure that when we run in javaRunLoopMode we don't exit randomly
+    [[NSRunLoop currentRunLoop] addPort:[NSPort port] forMode:[ThreadUtilities javaRunLoopMode]];
 
     do {
         @try {

--- a/src/java.desktop/macosx/native/libosxapp/PropertiesUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/PropertiesUtilities.h
@@ -23,14 +23,10 @@
  * questions.
  */
 
-/*
- * Must include this before JavaNativeFoundation.h to get jni.h from build
- */
 #include "jni.h"
 #include "jni_util.h"
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 
 JNIEXPORT @interface PropertiesUtilities : NSObject

--- a/src/java.desktop/macosx/native/libosxapp/PropertiesUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/PropertiesUtilities.m
@@ -33,12 +33,12 @@
     DECLARE_STATIC_METHOD_RETURN(jm_getProperty, jc_System,
                                  "getProperty", "(Ljava/lang/String;)Ljava/lang/String;", nil);
 
-    jstring jKey = JNFNSToJavaString(env, key);
+    jstring jKey = NSStringToJavaString(env, key);
     jstring jValue = (*env)->CallStaticObjectMethod(env, jc_System, jm_getProperty, jKey);
     (*env)->DeleteLocalRef(env, jKey);
     CHECK_EXCEPTION_NULL_RETURN(jValue, nil);
 
-    NSString *value = JNFJavaToNSString(env, jValue);
+    NSString *value = JavaStringToNSString(env, jValue);
     (*env)->DeleteLocalRef(env, jValue);
     return value;
 }

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.h
@@ -125,16 +125,16 @@ do {                                  \
 // --------------------------------------------------------------------------
 
 __attribute__((visibility("default")))
-@interface ThreadUtilities { }
+@interface ThreadUtilities : NSObject { } /* Extend NSObject so can call performSelectorOnMainThread */
 
 + (JNIEnv*)getJNIEnv;
 + (JNIEnv*)getJNIEnvUncached;
 + (void)detachCurrentThread;
 + (void)setAppkitThreadGroup:(jobject)group;
 
-//Wrappers for the corresponding JNFRunLoop methods with a check for main thread
 + (void)performOnMainThreadWaiting:(BOOL)wait block:(void (^)())block;
 + (void)performOnMainThread:(SEL)aSelector on:(id)target withObject:(id)arg waitUntilDone:(BOOL)wait;
++ (NSString*)javaRunLoopMode;
 @end
 
 JNIEXPORT void OSXAPP_SetJavaVM(JavaVM *vm);

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
@@ -24,7 +24,6 @@
  */
 
 #import <AppKit/AppKit.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <objc/message.h>
 
 #import "ThreadUtilities.h"
@@ -34,6 +33,8 @@
 JavaVM *jvm = NULL;
 static JNIEnv *appKitEnv = NULL;
 static jobject appkitThreadGroup = NULL;
+static NSString* JavaRunLoopMode = @"javaRunLoopMode";
+static NSArray<NSString*> *javaModes = nil;
 
 static inline void attachCurrentThread(void** env) {
     if ([NSThread isMainThread]) {
@@ -48,6 +49,15 @@ static inline void attachCurrentThread(void** env) {
 }
 
 @implementation ThreadUtilities
+
++ (void)initialize {
+    /* All the standard modes plus ours */
+    javaModes = [[NSArray alloc] initWithObjects:NSDefaultRunLoopMode,
+                                           NSModalPanelRunLoopMode,
+                                           NSEventTrackingRunLoopMode,
+                                           JavaRunLoopMode,
+                                           nil];
+}
 
 + (JNIEnv*)getJNIEnv {
 AWT_ASSERT_APPKIT_THREAD;
@@ -71,11 +81,34 @@ AWT_ASSERT_APPKIT_THREAD;
     appkitThreadGroup = group;
 }
 
+/* This is needed because we can't directly pass a block to
+ * performSelectorOnMainThreadWaiting .. since it expects a selector
+ */
++ (void)invokeBlock:(void (^)())block {
+  block();
+}
+
+/*
+ * When running a block where either we don't wait, or it needs to run on another thread
+ * we need to copy it from stack to heap, use the copy in the call and release after use.
+ * Do this only when we must because it could be expensive.
+ * Note : if waiting cross-thread, possibly the stack allocated copy is accessible ?
+ */
++ (void)invokeBlockCopy:(void (^)(void))blockCopy {
+  blockCopy();
+  Block_release(blockCopy);
+}
+
 + (void)performOnMainThreadWaiting:(BOOL)wait block:(void (^)())block {
     if ([NSThread isMainThread] && wait == YES) {
         block();
     } else {
-        [JNFRunLoop performOnMainThreadWaiting:wait withBlock:block];
+        if (wait == YES) {
+            [self performOnMainThread:@selector(invokeBlock:) on:self withObject:block waitUntilDone:YES];
+        } else {
+            void (^blockCopy)(void) = Block_copy(block);
+            [self performOnMainThread:@selector(invokeBlockCopy:) on:self withObject:blockCopy waitUntilDone:NO];
+        }
     }
 }
 
@@ -83,8 +116,12 @@ AWT_ASSERT_APPKIT_THREAD;
     if ([NSThread isMainThread] && wait == YES) {
         [target performSelector:aSelector withObject:arg];
     } else {
-        [JNFRunLoop performOnMainThread:aSelector on:target withObject:arg waitUntilDone:wait];
+        [target performSelectorOnMainThread:aSelector withObject:arg waitUntilDone:wait modes:javaModes];
     }
+}
+
++ (NSString*)javaRunLoopMode {
+    return JavaRunLoopMode;
 }
 
 @end

--- a/src/java.desktop/macosx/native/libosxui/AquaFileView.m
+++ b/src/java.desktop/macosx/native/libosxui/AquaFileView.m
@@ -30,7 +30,6 @@
 
 #import <sys/param.h> // for MAXPATHLEN
 #import <CoreFoundation/CoreFoundation.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 /*
  * Class:     com_apple_laf_AquaFileView
@@ -44,7 +43,7 @@
     jstring returnValue = NULL;
 JNI_COCOA_ENTER(env);
 
-    returnValue = JNFNSToJavaString(env, getRunningJavaBundle());
+    returnValue = NSStringToJavaString(env, getRunningJavaBundle());
 
 JNI_COCOA_EXIT(env);
     return returnValue;
@@ -61,7 +60,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_laf_AquaFileView_getNativePathToSharedJ
     jstring returnValue = NULL;
 JNI_COCOA_ENTER(env);
 
-    returnValue = JNFNSToJavaString(env, [[NSBundle bundleWithIdentifier:@"com.apple.JavaVM"] bundlePath]);
+    returnValue = NSStringToJavaString(env, [[NSBundle bundleWithIdentifier:@"com.apple.JavaVM"] bundlePath]);
 
 JNI_COCOA_EXIT(env);
     return returnValue;
@@ -79,7 +78,7 @@ JNIEXPORT jstring JNICALL Java_com_apple_laf_AquaFileView_getNativeMachineName
 JNI_COCOA_ENTER(env);
 
     CFStringRef machineName = CSCopyMachineName();
-    returnValue = JNFNSToJavaString(env, (NSString*)machineName);
+    returnValue = NSStringToJavaString(env, (NSString*)machineName);
 
     if (machineName != NULL) {
         CFRelease(machineName);
@@ -169,7 +168,7 @@ JNI_COCOA_ENTER(env);
         if (theErr == noErr) {
             CFMutableStringRef mutableDisplayName = CFStringCreateMutableCopy(NULL, 0, displayName);
             CFStringNormalize(mutableDisplayName, kCFStringNormalizationFormC);
-            returnValue = JNFNSToJavaString(env, (NSString *)mutableDisplayName);
+            returnValue = NSStringToJavaString(env, (NSString *)mutableDisplayName);
             CFRelease(mutableDisplayName);
         }
 

--- a/src/java.desktop/macosx/native/libosxui/AquaLookAndFeel.m
+++ b/src/java.desktop/macosx/native/libosxui/AquaLookAndFeel.m
@@ -23,11 +23,8 @@
  * questions.
  */
 
-// Must include this before JavaNativeFoundation.h to get jni.h from build
 #include "jni.h"
 #include "jni_util.h"
-
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 /*
  *    Empty JNI_OnLoad - needed to prevent:

--- a/src/java.desktop/macosx/native/libosxui/AquaNativeResources.m
+++ b/src/java.desktop/macosx/native/libosxui/AquaNativeResources.m
@@ -26,7 +26,6 @@
 #import "com_apple_laf_AquaNativeResources.h"
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 /*
  * Class:     com_apple_laf_AquaNativeResources

--- a/src/java.desktop/macosx/native/libosxui/JRSUIConstantSync.m
+++ b/src/java.desktop/macosx/native/libosxui/JRSUIConstantSync.m
@@ -23,7 +23,7 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
+#import "JNIUtilities.h"
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import "apple_laf_JRSUIConstants.h"

--- a/src/java.desktop/macosx/native/libosxui/JRSUIController.m
+++ b/src/java.desktop/macosx/native/libosxui/JRSUIController.m
@@ -23,7 +23,7 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
+#import "JNIUtilities.h"
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import "apple_laf_JRSUIControl.h"

--- a/src/java.desktop/macosx/native/libosxui/JRSUIFocus.m
+++ b/src/java.desktop/macosx/native/libosxui/JRSUIFocus.m
@@ -23,7 +23,7 @@
  * questions.
  */
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
+#import "JNIUtilities.h"
 
 #import "apple_laf_JRSUIFocus.h"
 #import "apple_laf_JRSUIControl.h"

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.h
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.h
@@ -25,4 +25,3 @@
 
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.m
@@ -31,7 +31,6 @@
 #import "java_awt_event_InputEvent.h"
 #import "java_awt_event_MouseEvent.h"
 
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #import "ThreadUtilities.h"
@@ -109,7 +108,7 @@ JNI_COCOA_ENTER(env);
     //NSLog(@"menuWillOpen %@", [menu title]);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_invokeOpenLater, sjc_ScreenMenu, "invokeOpenLater", "()V");
-    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_invokeOpenLater); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_invokeOpenLater);
     CHECK_EXCEPTION();
 JNI_COCOA_EXIT(env);
 
@@ -129,7 +128,7 @@ JNI_COCOA_ENTER(env);
     //NSLog(@"menuDidClose %@", [menu title]);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_invokeMenuClosing, sjc_ScreenMenu, "invokeMenuClosing", "()V");
-    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_invokeMenuClosing); // AWT_THREADING Safe (AWTRunLoopMode)
+    (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_invokeMenuClosing);
     CHECK_EXCEPTION();
 JNI_COCOA_EXIT(env);
 }
@@ -150,12 +149,22 @@ JNI_COCOA_ENTER(env);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_updateSelectedItem, sjc_ScreenMenu, "handleItemTargeted", "(IIIII)V");
     (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_updateSelectedItem, menuIndex,
-                    NSMinY(rect), NSMinX(rect), NSMaxY(rect), NSMaxX(rect)); // AWT_THREADING Safe (AWTRunLoopMode)
+                    NSMinY(rect), NSMinX(rect), NSMaxY(rect), NSMaxX(rect));
     CHECK_EXCEPTION();
 
 JNI_COCOA_EXIT(env);
 }
 
+/*
+ * The input is an NSTimeInterval (a double representing seconds and fractions of seconds)
+ * 0.0 means midnight Jan 1, 2001.
+ * The output is a Java long representing time in milliseconds since midnight Jan 1st 1970.
+ * There is a Cocoa constant representing that difference : NSTimeIntervalSince1970
+ */
+static jlong NSTimeIntervalToJavaMilliseconds(NSTimeInterval interval) {
+    NSTimeInterval interval1970 = interval + NSTimeIntervalSince1970;
+    return (jlong)(interval1970 * 1000);
+}
 
 // Called from event handler callback
 - (void)handleJavaMouseEvent:(NSEvent *)event
@@ -187,7 +196,7 @@ JNI_COCOA_EXIT(env);
     jint javaModifiers = ns2awtModifiers([event modifierFlags]) | ns2awtMouseButton([event buttonNumber]);
 
     // Get the event time
-    jlong javaWhen = JNFNSTimeIntervalToJavaMillis([event timestamp]);
+    jlong javaWhen = NSTimeIntervalToJavaMilliseconds([event timestamp]);
 
     // Call the mouse event handler, which will generate Java mouse events.
     JNIEnv *env = [ThreadUtilities getJNIEnv];
@@ -195,7 +204,7 @@ JNI_COCOA_ENTER(env);
     GET_SCREENMENU_CLASS();
     DECLARE_METHOD(jm_ScreenMenu_handleMouseEvent, sjc_ScreenMenu, "handleMouseEvent", "(IIIIJ)V");
     (*env)->CallVoidMethod(env, self.javaObject, jm_ScreenMenu_handleMouseEvent,
-             javaKind, javaX, javaY, javaModifiers, javaWhen); // AWT_THREADING Safe (AWTRunLoopMode)
+             javaKind, javaX, javaY, javaModifiers, javaWhen);
     CHECK_EXCEPTION();
 JNI_COCOA_EXIT(env);
 }
@@ -221,7 +230,7 @@ JNI_COCOA_ENTER(env);
     delegate = [[[NativeToJavaDelegate alloc] initFromMenu:menu javaObj:listenerRef] autorelease];
     CFRetain(delegate); // GC
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^{
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^{
         NSMenu *menu = delegate.nsmenu;
         if ([menu isJavaMenu]) {
             [menu setDelegate:delegate];
@@ -248,7 +257,7 @@ JNI_COCOA_ENTER(env);
 
     NativeToJavaDelegate *delegate = (NativeToJavaDelegate *)jlong_to_ptr(fModelPtr);
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^{
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^{
         NSMenu *menu = delegate.nsmenu;
         [menu setJavaMenuDelegate:nil];
         [menu setDelegate:nil];

--- a/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
+++ b/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
@@ -29,7 +29,6 @@
 #import <objc/objc-auto.h>
 
 #include <Security/AuthSession.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
 #import "NSApplicationAWT.h"
 
 #include <sys/time.h>
@@ -226,7 +225,7 @@ SplashInitPlatform(Splash * splash) {
 
     // If we are running SWT we should not start a runLoop
     if (!isSWTRunning()) {
-        [JNFRunLoop performOnMainThreadWaiting:NO withBlock:^() {
+        [ThreadUtilities performOnMainThreadWaiting:NO block:^() {
             [NSApplicationAWT runAWTLoopWithApp:[NSApplicationAWT sharedApplication]];
         }];
     }
@@ -243,7 +242,7 @@ SplashDonePlatform(Splash * splash) {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
     pthread_mutex_destroy(&splash->lock);
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         if (splash->window) {
             [splash->window orderOut:nil];
             [splash->window release];
@@ -282,7 +281,7 @@ void
 SplashRedrawWindow(Splash * splash) {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         // drop the reference to the old view and image
         [splash->window setContentView: nil];
         SplashUpdateScreenData(splash);
@@ -341,7 +340,7 @@ SplashRedrawWindow(Splash * splash) {
 void SplashReconfigureNow(Splash * splash) {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         SplashCenter(splash);
 
         if (!splash->window) {
@@ -430,7 +429,7 @@ SplashScreenThread(void *param) {
         fcntl(splash->controlpipe[0], F_GETFL, 0) | O_NONBLOCK);
     splash->time = SplashTime();
     splash->currentFrame = 0;
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
         SplashCenter(splash);
 
         splash->window = (void*) [[NSWindow alloc]
@@ -445,7 +444,7 @@ SplashScreenThread(void *param) {
     }];
     fflush(stdout);
     if (splash->window) {
-        [JNFRunLoop performOnMainThreadWaiting:YES withBlock:^(){
+        [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
             [splash->window orderFrontRegardless];
         }];
         SplashRedrawWindow(splash);

--- a/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.m
+++ b/test/jdk/java/awt/Window/MainKeyWindowTest/libTestMainKeyWindow.m
@@ -24,10 +24,44 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
+#import <jni_util.h>
 
 static NSWindow *testWindow;
 static NSColorPanel *colorPanel;
+
+#define JNI_COCOA_ENTER(env) \
+ NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
+ @try {
+
+#define JNI_COCOA_EXIT(env) \
+ } \
+ @catch (NSException *e) { \
+     NSLog(@"%@", [e callStackSymbols]); \
+ } \
+ @finally { \
+    [pool drain]; \
+  };
+
+/*
+ * Pass the block to a selector of a class that extends NSObject
+ * There is no need to copy the block since this class always waits.
+ */
+@interface BlockRunner : NSObject { }
+
++ (void)invokeBlock:(void (^)())block;
+@end
+
+@implementation BlockRunner
+
++ (void)invokeBlock:(void (^)())block{
+  block();
+}
+
++ (void)performBlock:(void (^)())block {
+  [self performSelectorOnMainThread:@selector(invokeBlock:) withObject:block waitUntilDone:YES];
+}
+
+@end
 
 /*
  * Class:     TestMainKeyWindow
@@ -36,7 +70,7 @@ static NSColorPanel *colorPanel;
  */
 JNIEXPORT void JNICALL Java_TestMainKeyWindow_setup(JNIEnv *env, jclass cl)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     void (^block)() = ^(){
         NSScreen *mainScreen = [NSScreen mainScreen];
@@ -68,10 +102,10 @@ JNIEXPORT void JNICALL Java_TestMainKeyWindow_setup(JNIEnv *env, jclass cl)
     if ([NSThread isMainThread]) {
         block();
     } else {
-        [JNFRunLoop performOnMainThreadWaiting:YES withBlock:block];
+        [BlockRunner performBlock:block];
     }
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -81,7 +115,7 @@ JNIEXPORT void JNICALL Java_TestMainKeyWindow_setup(JNIEnv *env, jclass cl)
  */
 JNIEXPORT void JNICALL Java_TestMainKeyWindow_takedown(JNIEnv *env, jclass cl)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     void (^block)() = ^(){
         if (testWindow != nil) {
@@ -97,10 +131,10 @@ JNIEXPORT void JNICALL Java_TestMainKeyWindow_takedown(JNIEnv *env, jclass cl)
     if ([NSThread isMainThread]) {
         block();
     } else {
-        [JNFRunLoop performOnMainThreadWaiting:YES withBlock:block];
+        [BlockRunner performBlock:block];
     }
 
-    JNF_COCOA_EXIT(env);
+    JNI_COCOA_EXIT(env);
 }
 
 /*
@@ -111,13 +145,13 @@ JNIEXPORT void JNICALL Java_TestMainKeyWindow_takedown(JNIEnv *env, jclass cl)
 JNIEXPORT void JNICALL Java_TestMainKeyWindow_activateApplication
   (JNIEnv *env, jclass cl)
 {
-    JNF_COCOA_ENTER(env);
+    JNI_COCOA_ENTER(env);
 
     void (^block)() = ^(){
         [NSApp activateIgnoringOtherApps:YES];
     };
 
-    [JNFRunLoop performOnMainThreadWaiting:YES withBlock:block];
+    [BlockRunner performBlock:block];
 
-  JNF_COCOA_EXIT(env);
+  JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
This is part 7/8 of JNF removal patches

Original [commit](https://github.com/openjdk/jdk/commit/8760688d213865eaf1bd675056eb809cdae67048) didn't apply cleanly due to:
-Changes in CPrinterJob.m in jdk16/17
-Missing CommonTextAccessibility.m ( such functionality is missing in jdk15 completely)
Please review this patch fo jdk15u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260616](https://bugs.openjdk.java.net/browse/JDK-8260616): Removing remaining JNF dependencies in the java.desktop module ⚠️ Issue is not open.


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/13.diff">https://git.openjdk.java.net/jdk15u-dev/pull/13.diff</a>

</details>
