### PR TITLE
8257988: Remove JNF dependency from libsaproc/MacosxDebuggerLocal.m

### DIFF
--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -67,7 +67,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBSA, \
     EXTRA_SRC := $(LIBSA_EXTRA_SRC), \
     LDFLAGS := $(LDFLAGS_JDKLIB), \
     LIBS_linux := $(LIBDL), \
-    LIBS_macosx := -framework Foundation -framework JavaNativeFoundation \
+    LIBS_macosx := -framework Foundation \
         -framework JavaRuntimeSupport -framework Security -framework CoreFoundation, \
     LIBS_windows := dbgeng.lib, \
 ))

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -24,8 +24,6 @@
 
 #include <objc/objc-runtime.h>
 #import <Foundation/Foundation.h>
-#import <JavaNativeFoundation/JavaNativeFoundation.h>
-#import <JavaRuntimeSupport/JavaRuntimeSupport.h>
 
 #include <jni.h>
 
@@ -260,6 +258,39 @@ jlong lookupByNameIncore(
   return addr;
 }
 
+/* Create a pool and initiate a try block to catch any exception */
+#define JNI_COCOA_ENTER(env) \
+ NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; \
+ @try {
+
+/* Don't allow NSExceptions to escape to Java.
+ * If there is a Java exception that has been thrown that should escape.
+ * And ensure we drain the auto-release pool.
+ */
+#define JNI_COCOA_EXIT(env) \
+ } \
+ @catch (NSException *e) { \
+     NSLog(@"%@", [e callStackSymbols]); \
+ } \
+ @finally { \
+    [pool drain]; \
+ };
+
+static NSString* JavaStringToNSString(JNIEnv *env, jstring jstr) {
+
+    if (jstr == NULL) {
+        return NULL;
+    }
+    jsize len = (*env)->GetStringLength(env, jstr);
+    const jchar *chars = (*env)->GetStringChars(env, jstr, NULL);
+    if (chars == NULL) {
+        return NULL;
+    }
+    NSString *result = [NSString stringWithCharacters:(UniChar *)chars length:len];
+    (*env)->ReleaseStringChars(env, jstr, chars);
+    return result;
+}
+
 /*
  * Class:     sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal
  * Method:    lookupByName0
@@ -277,8 +308,9 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_lookupByName0(
 
   jlong address = 0;
 
-JNF_COCOA_ENTER(env);
-  NSString *symbolNameString = JNFJavaToNSString(env, symbolName);
+  JNI_COCOA_ENTER(env);
+
+  NSString *symbolNameString = JavaStringToNSString(env, symbolName);
 
   print_debug("lookupInProcess called for %s\n", [symbolNameString UTF8String]);
 
@@ -289,7 +321,7 @@ JNF_COCOA_ENTER(env);
   }
 
   print_debug("address of symbol %s = %llx\n", [symbolNameString UTF8String], address);
-JNF_COCOA_EXIT(env);
+  JNI_COCOA_EXIT(env);
 
   return address;
 }
@@ -806,7 +838,7 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach0__I(
 {
   print_debug("attach0 called for jpid=%d\n", (int)jpid);
 
-JNF_COCOA_ENTER(env);
+  JNI_COCOA_ENTER(env);
 
   kern_return_t result;
   task_t gTask = 0;
@@ -920,7 +952,7 @@ JNF_COCOA_ENTER(env);
     THROW_NEW_DEBUGGER_EXCEPTION("Can't attach symbolicator to the process");
   }
 
-JNF_COCOA_EXIT(env);
+  JNI_COCOA_EXIT(env);
 }
 
 /** For core file,
@@ -1014,7 +1046,8 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_detach0(
      Prelease(ph);
      return;
   }
-JNF_COCOA_ENTER(env);
+
+  JNI_COCOA_ENTER(env);
 
   task_t gTask = getTask(env, this_obj);
   kern_return_t k_res = 0;
@@ -1065,5 +1098,5 @@ JNF_COCOA_ENTER(env);
 
   detach_cleanup(gTask, env, this_obj, false);
 
-JNF_COCOA_EXIT(env);
+  JNI_COCOA_EXIT(env);
 }


### PR DESCRIPTION
Clean backport, part 8/8 of JNF removal

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257988](https://bugs.openjdk.java.net/browse/JDK-8257988): Remove JNF dependency from libsaproc/MacosxDebuggerLocal.m


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/14.diff">https://git.openjdk.java.net/jdk15u-dev/pull/14.diff</a>

</details>
