### PR TITLE
8261231: Windows IME was disabled after DnD operation

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Toolkit.cpp
@@ -3216,10 +3216,12 @@ LRESULT AwtToolkit::InvokeInputMethodFunction(UINT msg, WPARAM wParam, LPARAM lP
      * function once the DND is active; otherwise a hang is possible since DND may wait for
      * the IME completion.
      */
+    CriticalSection::Lock lock(m_inputMethodLock);
     if (isInDoDragDropLoop) {
-        return SendMessage(msg, wParam, lParam);
+        SendMessage(msg, wParam, lParam);
+        ::ResetEvent(m_inputMethodWaitEvent);
+        return m_inputMethodData;
     } else {
-        CriticalSection::Lock lock(m_inputMethodLock);
         if (PostMessage(msg, wParam, lParam)) {
             ::WaitForSingleObject(m_inputMethodWaitEvent, INFINITE);
             return m_inputMethodData;


### PR DESCRIPTION
bug reproduced in the current state jdk15u-dev (with JDK-8252470) and fix worked there as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8261231](https://bugs.openjdk.java.net/browse/JDK-8261231): Windows IME was disabled after DnD operation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/15.diff">https://git.openjdk.java.net/jdk15u-dev/pull/15.diff</a>

</details>
