### PR TITLE
8262446: DragAndDrop hangs on Windows

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_DnDDT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,7 @@ static void ScaleDown(POINT &cp, HWND m_window) {
 
 HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWORD grfKeyState, POINTL pt, DWORD __RPC_FAR *pdwEffect) {
     TRY;
+    AwtToolkit::GetInstance().isInDoDragDropLoop = TRUE;
     if (NULL != m_pIDropTargetHelper) {
         m_pIDropTargetHelper->DragEnter(
             m_window,
@@ -160,6 +161,7 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
         (IsLocalDnD()  && !IsLocalDataObject(pDataObj)))
     {
         *pdwEffect = retEffect;
+        AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
         return ret;
     }
 
@@ -171,6 +173,7 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
     }
 
     if (JNU_IsNull(env, m_dtcp) || !JNU_IsNull(env, safe_ExceptionOccurred(env))) {
+        AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
         return ret;
     }
 
@@ -197,10 +200,12 @@ HRESULT __stdcall AwtDropTarget::DragEnter(IDataObject __RPC_FAR *pDataObj, DWOR
                 env->ExceptionDescribe();
                 env->ExceptionClear();
                 actions = java_awt_dnd_DnDConstants_ACTION_NONE;
+                AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
             }
         } catch (std::bad_alloc&) {
             retEffect = ::convertActionsToDROPEFFECT(actions);
             *pdwEffect = retEffect;
+            AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
             throw;
         }
 
@@ -416,6 +421,7 @@ void AwtDropTarget::DropDone(jboolean success, jint action) {
     m_dropSuccess = success;
     m_dropActions = action;
     AwtToolkit::GetInstance().QuitMessageLoop(AwtToolkit::EXIT_ENCLOSING_LOOP);
+    AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
 }
 
 /**
@@ -1130,6 +1136,7 @@ void AwtDropTarget::UnloadCache() {
 
 void AwtDropTarget::DragCleanup(void) {
     UnloadCache();
+    AwtToolkit::GetInstance().isInDoDragDropLoop = FALSE;
 }
 
 BOOL AwtDropTarget::IsLocalDataObject(IDataObject __RPC_FAR *pDataObject) {


### PR DESCRIPTION
backporting as follow-up to 8232114. Applies clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8262446](https://bugs.openjdk.java.net/browse/JDK-8262446): DragAndDrop hangs on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/16.diff">https://git.openjdk.java.net/jdk15u-dev/pull/16.diff</a>

</details>
