### PR TITLE
8257414: Drag n Drop target area is wrong on high DPI systems

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XDragSourceContextPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDragSourceContextPeer.java
@@ -524,8 +524,8 @@ public final class XDragSourceContextPeer
         updateTargetWindow(xmotion);
 
         if (dragProtocol != null) {
-            dragProtocol.sendMoveMessage(scaleDown(xmotion.get_x_root()),
-                                         scaleDown(xmotion.get_y_root()),
+            dragProtocol.sendMoveMessage(xmotion.get_x_root(),
+                                         xmotion.get_y_root(),
                                          sourceAction, sourceActions,
                                          xmotion.get_time());
         }
@@ -533,8 +533,8 @@ public final class XDragSourceContextPeer
 
     private void processDrop(XButtonEvent xbutton) {
         try {
-            dragProtocol.initiateDrop(scaleDown(xbutton.get_x_root()),
-                                      scaleDown(xbutton.get_y_root()),
+            dragProtocol.initiateDrop(xbutton.get_x_root(),
+                                      xbutton.get_y_root(),
                                       sourceAction, sourceActions,
                                       xbutton.get_time());
         } catch (XException e) {


### PR DESCRIPTION
I'd like to backport JDK-8257414 to jdk15u for parity with jdk11u.
The original patch applied cleanly.
Tested manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257414](https://bugs.openjdk.java.net/browse/JDK-8257414): Drag n Drop target area is wrong on high DPI systems


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/21.diff">https://git.openjdk.java.net/jdk15u-dev/pull/21.diff</a>

</details>
