### PR TITLE
8259319: Illegal package access when SunPKCS11 requires SunJCE's classes

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -133,6 +133,8 @@ module java.base {
     // additional qualified exports may be inserted at build time
     // see make/gensrc/GenModuleInfo.gmk
 
+    exports com.sun.crypto.provider to
+        jdk.crypto.cryptoki;
     exports sun.invoke.util to
         jdk.compiler,
         jdk.incubator.foreign;

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -124,6 +124,8 @@ grant codeBase "jrt:/jdk.crypto.ec" {
 
 grant codeBase "jrt:/jdk.crypto.cryptoki" {
     permission java.lang.RuntimePermission
+                   "accessClassInPackage.com.sun.crypto.provider";
+    permission java.lang.RuntimePermission
                    "accessClassInPackage.sun.security.*";
     permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
     permission java.lang.RuntimePermission "loadLibrary.j2pkcs11";

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,12 +88,27 @@ public final class P11Util {
         p = Security.getProvider(providerName);
         if (p == null) {
             try {
-                @SuppressWarnings("deprecation")
-                Object o = Class.forName(className).newInstance();
-                p = (Provider)o;
-            } catch (Exception e) {
-                throw new ProviderException
-                        ("Could not find provider " + providerName, e);
+                final Class<?> c = Class.forName(className);
+                p = AccessController.doPrivileged(
+                    new PrivilegedAction<Provider>() {
+                        public Provider run() {
+                            try {
+                                @SuppressWarnings("deprecation")
+                                Object o = c.newInstance();
+                                return (Provider) o;
+                            } catch (Exception e) {
+                                throw new ProviderException(
+                                        "Could not find provider " +
+                                                providerName, e);
+                            }
+                        }
+                    }, null, new RuntimePermission(
+                            "accessClassInPackage." + c.getPackageName()));
+            } catch (ClassNotFoundException e) {
+                // Unexpected, as className is not a user but a
+                // P11Util-internal value.
+                throw new ProviderException("Could not find provider " +
+                        providerName, e);
             }
         }
         return p;

--- a/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.security.AllPermission;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.ProtectionDomain;
+import java.security.Provider;
+import java.security.Security;
+import java.security.spec.X509EncodedKeySpec;
+
+/*
+ * @test
+ * @bug 8259319
+ * @library /test/lib ..
+ * @run main/othervm IllegalPackageAccess
+ */
+
+public class IllegalPackageAccess extends PKCS11Test {
+
+    private static Policy policy = Policy.getPolicy();
+    private static RuntimePermission accessPerm =
+            new RuntimePermission("accessClassInPackage.com.sun.crypto.provider");
+
+    private static class MyPolicy extends Policy {
+        @Override
+        public PermissionCollection getPermissions(ProtectionDomain domain) {
+            PermissionCollection perms = new Permissions();
+            perms.add(new AllPermission());
+            return perms;
+        }
+
+        @Override
+        public boolean implies(ProtectionDomain domain, Permission permission) {
+            if (permission.equals(accessPerm)) {
+                return policy.implies(domain, permission);
+            }
+            return super.implies(domain, permission);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        main(new IllegalPackageAccess(), args);
+        System.out.println("TEST PASS - OK");
+    }
+
+    @Override
+    public void main(Provider p) throws Exception {
+        Policy.setPolicy(new MyPolicy());
+        System.setSecurityManager(new SecurityManager());
+
+        // Remove all security providers so a fallback scheme
+        // that creates class instances is forced.
+        for (Provider provider : Security.getProviders()) {
+            Security.removeProvider(provider.getName());
+        }
+
+        KeyPair kp = KeyPairGenerator.getInstance("DH", p)
+                .generateKeyPair();
+        byte[] encPubKey = kp.getPublic().getEncoded();
+        KeyFactory kf = KeyFactory.getInstance("DH", p);
+
+        // Requires access to a SunJCE class that parses
+        // the encoded key.
+        kf.generatePublic(new X509EncodedKeySpec(encPubKey));
+
+        System.setSecurityManager(null);
+        Policy.setPolicy(policy);
+    }
+
+}


### PR DESCRIPTION
The original patch applies clean. No regressions in jdk/sun/security/pkcs11 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259319](https://bugs.openjdk.java.net/browse/JDK-8259319): Illegal package access when SunPKCS11 requires SunJCE's classes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/22.diff">https://git.openjdk.java.net/jdk15u-dev/pull/22.diff</a>

</details>
