### PR TITLE
8259585: [macos] Bad JNI lookup error : Accessible actions do not work on macOS

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/JavaAccessibilityAction.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,8 @@
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
     DECLARE_CLASS_RETURN(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility", nil);
-    DECLARE_METHOD_RETURN(jm_getAccessibleActionDescription, sjc_CAccessibility, "getAccessibleActionDescription",
+    DECLARE_STATIC_METHOD_RETURN(jm_getAccessibleActionDescription, sjc_CAccessibility,
+                          "getAccessibleActionDescription",
                           "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)Ljava/lang/String;", nil);
 
     /* WeakGlobalRefs can be cleared at any time, so first get strong local refs and use those */
@@ -95,7 +96,7 @@
 {
     JNIEnv* env = [ThreadUtilities getJNIEnv];
     DECLARE_CLASS(sjc_CAccessibility, "sun/lwawt/macosx/CAccessibility");
-    DECLARE_METHOD(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction",
+    DECLARE_STATIC_METHOD(jm_doAccessibleAction, sjc_CAccessibility, "doAccessibleAction",
                     "(Ljavax/accessibility/AccessibleAction;ILjava/awt/Component;)V");
 
     (*env)->CallStaticVoidMethod(env, sjc_CAccessibility, jm_doAccessibleAction,


### PR DESCRIPTION
I'd like to backport JDK-8259585 to jdk15u for parity with jdk11u.
The original patch applied cleanly.
Tested with SwingSet2 demo as described in the comments to the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8259585](https://bugs.openjdk.java.net/browse/JDK-8259585): [macos] Bad JNI lookup error : Accessible actions do not work on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/25.diff">https://git.openjdk.java.net/jdk15u-dev/pull/25.diff</a>

</details>
