### PR TITLE
8247753: UIManager.getSytemLookAndFeelClassName() returns wrong value on Fedora 32

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -95,10 +95,19 @@ public abstract class UNIXToolkit extends SunToolkit
 
     @Override
     public String getDesktop() {
+        String gnome = "gnome";
         String gsi = AccessController.doPrivileged(
                         (PrivilegedAction<String>) ()
                                 -> System.getenv("GNOME_DESKTOP_SESSION_ID"));
-        return (gsi != null) ? "gnome" : null;
+        if (gsi != null) {
+            return gnome;
+        }
+
+        String desktop = AccessController.doPrivileged(
+                (PrivilegedAction<String>) ()
+                        -> System.getenv("XDG_CURRENT_DESKTOP"));
+        return (desktop != null && desktop.toLowerCase().contains(gnome))
+                ? gnome : null;
     }
 
     /**

--- a/test/jdk/javax/swing/LookAndFeel/SystemLookAndFeel/SystemLookAndFeelTest.java
+++ b/test/jdk/javax/swing/LookAndFeel/SystemLookAndFeel/SystemLookAndFeelTest.java
@@ -21,9 +21,9 @@
  * questions.
  */
 
- /*
+/*
  * @test
- * @bug 8226783
+ * @bug 8226783 8247753
  * @key headful
  * @summary Verify System L&F
  */
@@ -52,23 +52,26 @@ public class SystemLookAndFeelTest {
         } else if (os.contains("macos")) {
             expLAF = "com.apple.laf.AquaLookAndFeel";
         } else if (os.contains("linux")) {
-           /*
-            * The implementation keys off the following desktop setting to
-            * decide if GTK is an appropriate system L&F.
-            * In its absence, there probably isn't support for the GTK L&F
-            * anyway. It does not tell us if the GTK libraries are available
-            * but they really should be if this is a gnome session.
-            * If it proves necessary the test can perhaps be updated to see
-            * if the GTK LAF is listed as installed and can be instantiated.
-            */
-           String gnome = System.getenv("GNOME_DESKTOP_SESSION_ID");
-           System.out.println("Gnome desktop session ID is " + gnome);
-           if (gnome != null) {
-               expLAF = "com.sun.java.swing.plaf.gtk.GTKLookAndFeel";
-           } else if (os.contains("linux")) {
-               expLAF = "javax.swing.plaf.metal.MetalLookAndFeel";
-           }
-       }
+            /*
+             * The implementation keys off the following desktop setting to
+             * decide if GTK is an appropriate system L&F.
+             * In its absence, there probably isn't support for the GTK L&F
+             * anyway. It does not tell us if the GTK libraries are available
+             * but they really should be if this is a gnome session.
+             * If it proves necessary the test can perhaps be updated to see
+             * if the GTK LAF is listed as installed and can be instantiated.
+             */
+            String gnome = System.getenv("GNOME_DESKTOP_SESSION_ID");
+            String desktop = System.getenv("XDG_CURRENT_DESKTOP");
+            System.out.println("Gnome desktop session ID is " + gnome);
+            System.out.println("XDG_CURRENT_DESKTOP is set to " + desktop);
+            if (gnome != null ||
+                    (desktop != null && desktop.toLowerCase().contains("gnome"))) {
+                expLAF = "com.sun.java.swing.plaf.gtk.GTKLookAndFeel";
+            } else {
+                expLAF = "javax.swing.plaf.metal.MetalLookAndFeel";
+            }
+        }
         System.out.println("Expected System LAF is " + expLAF);
         if (expLAF == null) {
             System.out.println("No match for expected LAF, unknown OS ?");
@@ -77,5 +80,5 @@ public class SystemLookAndFeelTest {
         if (!(laf.equals(expLAF))) {
             throw new RuntimeException("LAF not as expected");
         }
-   }
+    }
 }


### PR DESCRIPTION
This port of a change necessary for  newer Gnome is clean on jdk15.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8247753](https://bugs.openjdk.java.net/browse/JDK-8247753): UIManager.getSytemLookAndFeelClassName() returns wrong value on Fedora 32


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/27.diff">https://git.openjdk.java.net/jdk15u-dev/pull/27.diff</a>

</details>
