### PR TITLE
8257242: [macOS] Java app crashes while switching input methods

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.h
@@ -37,9 +37,6 @@
 
     // TODO: NSMenu *contextualMenu;
 
-    // Keyboard layout
-    NSString *kbdLayout;
-
     // dnd support (see AppKit/NSDragging.h, NSDraggingSource/Destination):
     CDragSource *_dragSource;
     CDropTarget *_dropTarget;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -37,6 +37,9 @@
 
 #import <Carbon/Carbon.h>
 
+// keyboard layout
+static NSString *kbdLayout;
+
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
 @property (retain) CDragSource *_dragSource;
@@ -1010,7 +1013,7 @@ static jclass jc_CInputMethod = NULL;
     [self abandonInput];
 }
 
-- (void)keyboardInputSourceChanged:(NSNotification *)notification
++ (void)keyboardInputSourceChanged:(NSNotification *)notification
 {
 #ifdef IM_DEBUG
     NSLog(@"keyboardInputSourceChangeNotification received");
@@ -1327,7 +1330,7 @@ static jclass jc_CInputMethod = NULL;
     CHECK_EXCEPTION();
 
 #ifdef IM_DEBUG
-    fprintf(stderr, "characterIndexForPoint returning %ld\n", index);
+    fprintf(stderr, "characterIndexForPoint returning %d\n", index);
 #endif // IM_DEBUG
 
     if (index == -1) {


### PR DESCRIPTION
I'd like to backport JDK-8257242 to jdk15u for parity with jdk11u.
The original patch applied cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257242](https://bugs.openjdk.java.net/browse/JDK-8257242): [macOS] Java app crashes while switching input methods


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/32.diff">https://git.openjdk.java.net/jdk15u-dev/pull/32.diff</a>

</details>
