### PR TITLE
8256810: Incremental rebuild broken on Macosx

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -237,10 +237,15 @@ ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
         ) \
       )
 
-  # When compiling with relative paths, the deps file comes out with relative
-  # paths.
+  # When compiling with relative paths, the deps file may come out with relative
+  # paths, and that path may start with './'. First remove any leading ./, then
+  # add WORKSPACE_ROOT to any line not starting with /, while allowing for
+  # leading spaces.
   define fix-deps-file
-	$(SED) -e 's|^\([ ]*\)|\1$(WORKSPACE_ROOT)|' $1.tmp > $1
+	$(SED) \
+	    -e 's|^\([ ]*\)\./|\1|' \
+	    -e '/^[ ]*[^/ ]/s|^\([ ]*\)|\1$(WORKSPACE_ROOT)/|' \
+	    $1.tmp > $1
   endef
 else
   # By default the MakeCommandRelative macro does nothing.


### PR DESCRIPTION
This should be fixed in 15u, too, and after that, fix JDK-8257547

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8256810](https://bugs.openjdk.java.net/browse/JDK-8256810): Incremental rebuild broken on Macosx


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/33.diff">https://git.openjdk.java.net/jdk15u-dev/pull/33.diff</a>

</details>
