### PR TITLE
8257547: Handle multiple prereqs on the same line in deps files

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -240,12 +240,22 @@ ifeq ($(ALLOW_ABSOLUTE_PATHS_IN_OUTPUT)-$(FILE_MACRO_CFLAGS), false-)
   # When compiling with relative paths, the deps file may come out with relative
   # paths, and that path may start with './'. First remove any leading ./, then
   # add WORKSPACE_ROOT to any line not starting with /, while allowing for
-  # leading spaces.
+  # leading spaces. There may also be multiple entries on the same line, so start
+  # with splitting such lines.
+  # Non GNU sed (BSD on macosx) cannot substitue in literal \n using regex.
+  # Instead use a bash escaped literal newline. To avoid having unmatched quotes
+  # ruin the ability for an editor to properly syntax highlight this file, define
+  # that newline sequence as a separate variable and add the closing quote behind
+  # a comment.
+  sed_newline := \'$$'\n''#'
   define fix-deps-file
 	$(SED) \
-	    -e 's|^\([ ]*\)\./|\1|' \
-	    -e '/^[ ]*[^/ ]/s|^\([ ]*\)|\1$(WORKSPACE_ROOT)/|' \
-	    $1.tmp > $1
+	    -e 's|\([^ ]\) \{1,\}\([^\\:]\)|\1 \\$(sed_newline) \2|g' \
+	    $1.tmp \
+	    | $(SED) \
+	        -e 's|^\([ ]*\)\./|\1|' \
+	        -e '/^[ ]*[^/ ]/s|^\([ ]*\)|\1$(WORKSPACE_ROOT)/|' \
+	        > $1
   endef
 else
   # By default the MakeCommandRelative macro does nothing.

--- a/test/make/TestFixDepsFile.gmk
+++ b/test/make/TestFixDepsFile.gmk
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+default: all
+
+include $(SPEC)
+include MakeBase.gmk
+include UtilsForTests.gmk
+
+THIS_FILE := $(TOPDIR)/test/make/FixDepsFile.gmk
+DEPS := $(THIS_FILE) \
+    $(TOPDIR)/make/common/NativeCompilation.gmk \
+    #
+
+OUTPUT_DIR := $(TESTMAKE_OUTPUTDIR)/fix-deps-file
+$(call MakeDir, $(OUTPUT_DIR))
+
+################################################################################
+# The relevant case to test is when absolute paths aren't allowed.
+ALLOW_ABSOLUTE_PATHS_IN_OUTPUT := false
+FILE_MACRO_CFLAGS :=
+include NativeCompilation.gmk
+
+DEPS_FILE := $(OUTPUT_DIR)/deps.d
+
+test-fix-deps-file:
+	$(ECHO) "foo/bar1: \\" > $(DEPS_FILE).tmp
+	$(ECHO) "foo/baz1" >> $(DEPS_FILE).tmp
+	$(ECHO) "foo/bar : bar \\" >> $(DEPS_FILE).tmp
+	$(ECHO) " ./bar/baz /foo/baz" >> $(DEPS_FILE).tmp
+	$(call fix-deps-file, $(DEPS_FILE))
+	$(ECHO) "$(WORKSPACE_ROOT)/foo/bar1: \\" > $(DEPS_FILE).expected
+	$(ECHO) "$(WORKSPACE_ROOT)/foo/baz1" >> $(DEPS_FILE).expected
+	$(ECHO) "$(WORKSPACE_ROOT)/foo/bar : \\" >> $(DEPS_FILE).expected
+	$(ECHO) " $(WORKSPACE_ROOT)/bar \\" >> $(DEPS_FILE).expected
+	$(ECHO) " $(WORKSPACE_ROOT)/bar/baz \\" >> $(DEPS_FILE).expected
+	$(ECHO) " /foo/baz" >> $(DEPS_FILE).expected
+	$(DIFF) $(DEPS_FILE).expected $(DEPS_FILE)
+
+TEST_TARGETS := test-fix-deps-file
+
+################################################################################
+
+all: $(TEST_TARGETS)

--- a/test/make/TestMake.gmk
+++ b/test/make/TestMake.gmk
@@ -36,6 +36,9 @@ java-compilation:
 copy-files:
 	+$(MAKE) -f TestCopyFiles.gmk $(TEST_SUBTARGET)
 
+fix-deps-file:
+	+$(MAKE) -f TestFixDepsFile.gmk $(TEST_SUBTARGET)
+
 idea:
 	+$(MAKE) -f TestIdea.gmk $(TEST_SUBTARGET)
 
@@ -46,7 +49,8 @@ configure:
 	$(BASH) $(TOPDIR)/test/make/autoconf/test-configure.sh \
 	    "$(AUTOCONF)" "$(TOPDIR)" "$(TEST_SUPPORT_DIR)"
 
-TARGETS += make-base java-compilation copy-files idea compile-commands configure
+TARGETS += make-base java-compilation copy-files fix-deps-file idea \
+    compile-commands configure
 
 all: $(TARGETS)
 


### PR DESCRIPTION
The patch goes without adjustments. This fix is third in the series.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8257547](https://bugs.openjdk.java.net/browse/JDK-8257547): Handle multiple prereqs on the same line in deps files


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/36.diff">https://git.openjdk.java.net/jdk15u-dev/pull/36.diff</a>

</details>
