### PR TITLE
8250627: Use -XX:+/-UseContainerSupport for enabling/disabling Java container metrics

### DIFF
--- a/make/hotspot/symbols/symbols-linux
+++ b/make/hotspot/symbols/symbols-linux
@@ -22,6 +22,7 @@
 #
 
 JVM_handle_linux_signal
+JVM_IsUseContainerSupport
 numa_error
 numa_warn
 sysThreadAvailableStackWithSlack

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -158,6 +158,9 @@ JVM_MaxMemory(void);
 JNIEXPORT jint JNICALL
 JVM_ActiveProcessorCount(void);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsUseContainerSupport(void);
+
 JNIEXPORT void * JNICALL
 JVM_LoadLibrary(const char *name);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -543,7 +543,15 @@ JVM_ENTRY_NO_ENV(jint, JVM_ActiveProcessorCount(void))
   return os::active_processor_count();
 JVM_END
 
-
+JVM_ENTRY_NO_ENV(jboolean, JVM_IsUseContainerSupport(void))
+  JVMWrapper("JVM_IsUseContainerSupport");
+#ifdef LINUX
+  if (UseContainerSupport) {
+    return JNI_TRUE;
+  }
+#endif
+  return JNI_FALSE;
+JVM_END
 
 // java.lang.Throwable //////////////////////////////////////////////////////
 

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupMetrics.java
@@ -160,7 +160,13 @@ public class CgroupMetrics implements Metrics {
     }
 
     public static Metrics getInstance() {
+        if (!isUseContainerSupport()) {
+            // Return null on -XX:-UseContainerSupport
+            return null;
+        }
         return CgroupSubsystemFactory.create();
     }
+
+    private static native boolean isUseContainerSupport();
 
 }

--- a/src/java.base/linux/native/libjava/CgroupMetrics.c
+++ b/src/java.base/linux/native/libjava/CgroupMetrics.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "jvm.h"
+
+#include "jdk_internal_platform_CgroupMetrics.h"
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_platform_CgroupMetrics_isUseContainerSupport(JNIEnv *env, jclass ignored)
+{
+    return JVM_IsUseContainerSupport();
+}

--- a/test/jdk/jdk/internal/platform/docker/CheckUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/CheckUseContainerSupport.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.platform.Metrics;
+
+public class CheckUseContainerSupport {
+
+    // Usage: boolean value of -XX:+/-UseContainerSupport
+    //        passed as the only argument
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new RuntimeException("Expected only one boolean argument");
+        }
+        boolean expectedContainerSupport = Boolean.parseBoolean(args[0]);
+        boolean actualContainerSupport = (Metrics.systemMetrics() != null);
+        if (expectedContainerSupport != actualContainerSupport) {
+            String msg = "-XX:" + ( expectedContainerSupport ? "+" : "-") + "UseContainerSupport, but got " +
+                         "Metrics.systemMetrics() == " + (Metrics.systemMetrics() == null ? "null" : "non-null");
+            System.out.println(msg);
+            System.out.println("TEST FAILED!!!");
+            return;
+        }
+        System.out.println("TEST PASSED!!!");
+    }
+
+}

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary UseContainerSupport flag should reflect Metrics being available
+ * @requires docker.support
+ * @library /test/lib
+ * @modules java.base/jdk.internal.platform
+ * @build CheckUseContainerSupport
+ * @run main/timeout=360 TestUseContainerSupport
+ */
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.containers.docker.Common;
+import jdk.test.lib.containers.docker.DockerRunOptions;
+import jdk.test.lib.containers.docker.DockerTestUtils;
+
+public class TestUseContainerSupport {
+    private static final String imageName = Common.imageName("useContainerSupport");
+
+    public static void main(String[] args) throws Exception {
+        if (!DockerTestUtils.canTestDocker()) {
+            return;
+        }
+
+        DockerTestUtils.buildJdkDockerImage(imageName, "Dockerfile-BasicTest", "jdk-docker");
+
+        try {
+            testUseContainerSupport(true);
+            testUseContainerSupport(false);
+        } finally {
+            DockerTestUtils.removeDockerImage(imageName);
+        }
+    }
+
+    private static void testUseContainerSupport(boolean useContainerSupport) throws Exception {
+        String testMsg = " with -XX:" + (useContainerSupport ? "+" : "-") + "UseContainerSupport";
+        Common.logNewTestCase("Test TestUseContainerSupport" + testMsg);
+        DockerRunOptions opts =
+                new DockerRunOptions(imageName, "/jdk/bin/java", "CheckUseContainerSupport");
+        opts.addClassOptions(Boolean.valueOf(useContainerSupport).toString());
+        opts.addDockerOpts("--memory", "200m")
+            .addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
+        if (useContainerSupport) {
+            opts.addJavaOpts("-XX:+UseContainerSupport");
+        } else {
+            opts.addJavaOpts("-XX:-UseContainerSupport");
+        }
+        opts.addJavaOpts("-cp", "/test-classes/");
+        opts.addJavaOpts("--add-exports", "java.base/jdk.internal.platform=ALL-UNNAMED");
+        DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
+    }
+}


### PR DESCRIPTION
I would like to backport JDK-8250627 to 15u for parity with 11u.
The patch applies cleanly.
Tested with container tests, including new one and tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8250627](https://bugs.openjdk.java.net/browse/JDK-8250627): Use -XX:+/-UseContainerSupport for enabling/disabling Java container metrics


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/45.diff">https://git.openjdk.java.net/jdk15u-dev/pull/45.diff</a>

</details>
