### PR TITLE
8244500: jtreg test error in test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java

### DIFF
--- a/test/hotspot/jtreg/containers/docker/CheckOperatingSystemMXBean.java
+++ b/test/hotspot/jtreg/containers/docker/CheckOperatingSystemMXBean.java
@@ -24,11 +24,20 @@
 
 import com.sun.management.OperatingSystemMXBean;
 import java.lang.management.ManagementFactory;
+import jdk.internal.platform.Metrics;
 
 public class CheckOperatingSystemMXBean {
 
     public static void main(String[] args) {
         System.out.println("Checking OperatingSystemMXBean");
+        Metrics metrics = jdk.internal.platform.Container.metrics();
+        System.out.println("Metrics instance: " + (metrics == null ? "null" : "non-null"));
+        if (metrics != null) {
+            System.out.println("Metrics.getMemoryAndSwapLimit() == " + metrics.getMemoryAndSwapLimit());
+            System.out.println("Metrics.getMemoryLimit() == " + metrics.getMemoryLimit());
+            System.out.println("Metrics.getMemoryAndSwapUsage() == " + metrics.getMemoryAndSwapUsage());
+            System.out.println("Metrics.getMemoryUsage() == " + metrics.getMemoryUsage());
+        }
 
         OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
         System.out.println(String.format("Runtime.availableProcessors: %d", Runtime.getRuntime().availableProcessors()));

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -28,6 +28,7 @@
  * @requires docker.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build PrintContainerInfo CheckOperatingSystemMXBean
@@ -237,7 +238,11 @@ public class TestCPUAwareness {
         DockerRunOptions opts = Common.newOpts(imageName, "CheckOperatingSystemMXBean")
             .addDockerOpts(
                 "--cpus", cpuAllocation
-            );
+            )
+            // CheckOperatingSystemMXBean uses Metrics (jdk.internal.platform) for
+            // diagnostics
+            .addJavaOpts("--add-exports")
+            .addJavaOpts("java.base/jdk.internal.platform=ALL-UNNAMED");
 
         DockerTestUtils.dockerRunJava(opts)
             .shouldHaveExitValue(0)

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -28,6 +28,7 @@
  * @requires docker.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.platform
  *          java.management
  *          jdk.jartool/sun.tools.jar
  * @build AttemptOOM sun.hotspot.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean
@@ -142,7 +143,11 @@ public class TestMemoryAwareness {
             .addDockerOpts(
                 "--memory", memoryAllocation,
                 "--memory-swap", swapAllocation
-            );
+            )
+            // CheckOperatingSystemMXBean uses Metrics (jdk.internal.platform) for
+            // diagnostics
+            .addJavaOpts("--add-exports")
+            .addJavaOpts("java.base/jdk.internal.platform=ALL-UNNAMED");
 
         OutputAnalyzer out = DockerTestUtils.dockerRunJava(opts);
         out.shouldHaveExitValue(0)
@@ -153,11 +158,13 @@ public class TestMemoryAwareness {
            .shouldMatch("OperatingSystemMXBean\\.getFreeMemorySize: [1-9][0-9]+")
            .shouldMatch("OperatingSystemMXBean\\.getFreeSwapSpaceSize: [1-9][0-9]+");
         // in case of warnings like : "Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap."
-        // the getTotalSwapSpaceSize does not return the expected result, but 0
+        // the getTotalSwapSpaceSize returns the system values as the container setup isn't supported in that case.
         try {
             out.shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: " + expectedSwap);
         } catch(RuntimeException ex) {
-            out.shouldContain("OperatingSystemMXBean.getTotalSwapSpaceSize: 0");
+            out.shouldMatch("OperatingSystemMXBean.getTotalSwapSpaceSize: [1-9][0-9]+");
+            out.shouldContain("Metrics.getMemoryLimit() == " + expectedMemory);
+            out.shouldContain("Metrics.getMemoryAndSwapLimit() == -1");
         }
     }
 


### PR DESCRIPTION
I would like to backport JDK-8244500 to 15u as a prerequisite for JDK-8250984.
This is test-only fix, applies cleanly.
Tested with container tests, the affected tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8244500](https://bugs.openjdk.java.net/browse/JDK-8244500): jtreg test error in test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/46.diff">https://git.openjdk.java.net/jdk15u-dev/pull/46.diff</a>

</details>
