### PR TITLE
Backport 2fe0a5d75ee9434017b3df5cfa713ef895a19866

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -60,8 +60,7 @@ public class TestUseContainerSupport {
         DockerRunOptions opts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "CheckUseContainerSupport");
         opts.addClassOptions(Boolean.valueOf(useContainerSupport).toString());
-        opts.addDockerOpts("--memory", "200m")
-            .addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
+        opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/");
         if (useContainerSupport) {
             opts.addJavaOpts("-XX:+UseContainerSupport");
         } else {


### PR DESCRIPTION
I'd like to backport JDK-8253476 to 15u for parity with 11u.
The patch applies cleanly.
It is test-only change, the affected test passes after applying the patch.