### PR TITLE
8249215: JFrame::setVisible crashed with -Dfile.encoding=UTF-8 on Japanese Windows.

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WFontConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,13 +152,17 @@ public final class WFontConfiguration extends FontConfiguration {
 
     /**
      * Returns the component font name (face name plus charset) of the
-     * font that should be used for AWT text components. May return null.
+     * font that should be used for AWT text components.
      */
     public String getTextComponentFontName(String familyName, int style) {
         FontDescriptor[] fontDescriptors = getFontDescriptors(familyName, style);
         String fontName = findFontWithCharset(fontDescriptors, textInputCharset);
-        if (fontName == null) {
+        if ((fontName == null) && !textInputCharset.equals("DEFAULT_CHARSET")) {
             fontName = findFontWithCharset(fontDescriptors, "DEFAULT_CHARSET");
+        }
+        if (fontName == null) {
+            fontName = (fontDescriptors.length > 0) ? fontDescriptors[0].getNativeName()
+                                                    : "Arial,ANSI_CHARSET";
         }
         return fontName;
     }


### PR DESCRIPTION
The issue reported in 15, too, and should be backported here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8249215](https://bugs.openjdk.java.net/browse/JDK-8249215): JFrame::setVisible crashed with -Dfile.encoding=UTF-8 on Japanese Windows.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/55.diff">https://git.openjdk.java.net/jdk15u-dev/pull/55.diff</a>

</details>
