### PR TITLE
8255908: ExceptionInInitializerError due to UncheckedIOException while initializing cgroupv1 subsystem

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemController.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupSubsystemController.java
@@ -26,6 +26,7 @@
 package jdk.internal.platform;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -169,8 +170,9 @@ public interface CgroupSubsystemController {
                                            .findFirst();
 
             return result.isPresent() ? Long.parseLong(result.get()) : defaultRetval;
-        }
-        catch (IOException e) {
+        } catch (UncheckedIOException e) {
+            return defaultRetval;
+        } catch (IOException e) {
             return defaultRetval;
         }
     }

--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupUtil.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupUtil.java
@@ -27,6 +27,7 @@ package jdk.internal.platform;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,6 +46,8 @@ public final class CgroupUtil {
         } catch (PrivilegedActionException e) {
             unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 
@@ -68,6 +71,8 @@ public final class CgroupUtil {
         } catch (PrivilegedActionException e) {
             unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 
@@ -78,6 +83,8 @@ public final class CgroupUtil {
         } catch (PrivilegedActionException e) {
             unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
         }
     }
 }

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv1/CgroupV1Subsystem.java
@@ -26,6 +26,7 @@
 package jdk.internal.platform.cgroupv1;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
@@ -75,6 +76,8 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
                  .map(line -> line.split(" "))
                  .forEach(entry -> createSubSystemController(subsystem, entry));
 
+        } catch (UncheckedIOException e) {
+            return null;
         } catch (IOException e) {
             return null;
         }
@@ -109,6 +112,8 @@ public class CgroupV1Subsystem implements CgroupSubsystem, CgroupV1Metrics {
                  .filter(line -> (line.length >= 3))
                  .forEach(line -> setSubSystemControllerPath(subsystem, line));
 
+        } catch (UncheckedIOException e) {
+            return null;
         } catch (IOException e) {
             return null;
         }

--- a/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/cgroupv2/CgroupV2Subsystem.java
@@ -26,6 +26,7 @@
 package jdk.internal.platform.cgroupv2;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +70,8 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
                             .collect(Collectors.joining());
             String[] tokens = l.split(" ");
             mountPath = tokens[4];
+        } catch (UncheckedIOException e) {
+            return null;
         } catch (IOException e) {
             return null;
         }
@@ -87,6 +90,8 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
                 cgroupPath = tokens[2];
                 break;
             }
+        } catch (UncheckedIOException e) {
+            return null;
         } catch (IOException e) {
             return null;
         }
@@ -329,6 +334,8 @@ public class CgroupV2Subsystem implements CgroupSubsystem {
             return CgroupUtil.readFilePrivileged(Paths.get(unified.path(), "io.stat"))
                                 .map(mapFunc)
                                 .collect(Collectors.summingLong(e -> e));
+        } catch (UncheckedIOException e) {
+            return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
         } catch (IOException e) {
             return CgroupSubsystem.LONG_RETVAL_UNLIMITED;
         }


### PR DESCRIPTION
I'd like to backport JDK-8255908 to 15u for parity with 11u.
The patch applies cleanly.
Tested with tier1 and container tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255908](https://bugs.openjdk.java.net/browse/JDK-8255908): ExceptionInInitializerError due to UncheckedIOException while initializing cgroupv1 subsystem


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/57.diff">https://git.openjdk.java.net/jdk15u-dev/pull/57.diff</a>

</details>
