### PR TITLE
8251257: NMT: jcmd VM.native_memory scale=1 crashes target VM

### DIFF
--- a/src/hotspot/share/services/nmtCommon.cpp
+++ b/src/hotspot/share/services/nmtCommon.cpp
@@ -35,6 +35,7 @@ const char* NMTUtil::_memory_type_names[] = {
 
 const char* NMTUtil::scale_name(size_t scale) {
   switch(scale) {
+    case 1: return "";
     case K: return "KB";
     case M: return "MB";
     case G: return "GB";

--- a/test/hotspot/jtreg/runtime/NMT/JcmdScale.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdScale.java
@@ -42,6 +42,14 @@ public class JcmdScale {
     // Grab my own PID
     String pid = Long.toString(ProcessTools.getProcessId());
 
+    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "scale=1"});
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain(", committed=");
+
+    pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "scale=b"});
+    output = new OutputAnalyzer(pb.start());
+    output.shouldContain(", committed=");
+
     pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "scale=KB"});
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("KB, committed=");


### PR DESCRIPTION
I'd like to backport JDK-8251257 to 15u for parity with 11u.
The patch applies cleanly.
Tested with tier1 and nmt tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8251257](https://bugs.openjdk.java.net/browse/JDK-8251257): NMT: jcmd VM.native_memory scale=1 crashes target VM


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/58.diff">https://git.openjdk.java.net/jdk15u-dev/pull/58.diff</a>

</details>
