### PR TITLE
8251456: [TESTBUG] compiler/vectorization/TestVectorsNotSavedAtSafepoint.java failed OutOfMemoryError

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorsNotSavedAtSafepoint.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8193518 8249608
  * @summary C2: Vector registers are sometimes corrupted at safepoint
- * @run main/othervm -XX:-BackgroundCompilation -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+IgnoreUnrecognizedVMOptions -XX:+UseCountedLoopSafepoints -XX:LoopStripMiningIter=2 -XX:-TieredCompilation TestVectorsNotSavedAtSafepoint test1
  * @run main/othervm -XX:-BackgroundCompilation TestVectorsNotSavedAtSafepoint test2
  */
 


### PR DESCRIPTION
I'd like to backport JDK-8251456 to jdk15u for parity with jdk11u.
The original patch applied cleanly.

Slight changes is made to the test: added -XX:+IgnoreUnrecognizedVMOptions as suggested in JDK-8264179, - due to tier1 on win32 failed with "Unrecognized VM option 'UseCountedLoopSafepoints' ". 

All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251456](https://bugs.openjdk.java.net/browse/JDK-8251456): [TESTBUG] compiler/vectorization/TestVectorsNotSavedAtSafepoint.java failed OutOfMemoryError


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/65.diff">https://git.openjdk.java.net/jdk15u-dev/pull/65.diff</a>

</details>
