### PR TITLE
8253299: Manifest bytes are read twice when verifying a signed JAR

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -734,6 +734,7 @@ public class JarFile extends ZipFile {
             List<String> names = JUZFA.getManifestAndSignatureRelatedFiles(this);
             for (String name : names) {
                 JarEntry e = getJarEntry(name);
+                byte[] b;
                 if (e == null) {
                     throw new JarException("corrupted jar file");
                 }
@@ -741,7 +742,11 @@ public class JarFile extends ZipFile {
                     mev = new ManifestEntryVerifier
                         (getManifestFromReference());
                 }
-                byte[] b = getBytes(e);
+                if (name.equals(MANIFEST_NAME)) {
+                    b = jv.manifestRawBytes;
+                } else {
+                    b = getBytes(e);
+                }
                 if (b != null && b.length > 0) {
                     jv.beginEntry(e, mev);
                     jv.update(b.length, b, 0, b.length, mev);


### PR DESCRIPTION
I'd like to port this fix here, too. Applies cleanly, all jdk/java/util/jar tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253299](https://bugs.openjdk.java.net/browse/JDK-8253299): Manifest bytes are read twice when verifying a signed JAR


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/67.diff">https://git.openjdk.java.net/jdk15u-dev/pull/67.diff</a>

</details>
