### PR TITLE
8255992: JFR EventWriter does not use first string from StringPool with id 0

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/StringPool.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/StringPool.java
@@ -49,7 +49,7 @@ public final class StringPool {
     }
     private static class SimpleStringIdPool {
         /* string id index */
-        private final AtomicLong sidIdx = new AtomicLong();
+        private final AtomicLong sidIdx = new AtomicLong(1);
         /* epoch of cached strings */
         private boolean poolEpoch;
         /* the cache */


### PR DESCRIPTION
I'd like to backport JDK-8255992 to 15u as a prerequisite for JDK-8257621 and for parity with 11u.
The patch applies cleanly.
Tested with tier1 and jdk/jfr tests, the only failure is jdk/jfr/api/recording/event/TestReEnableName.java, that will be fixed by follow-up backport of JDK-8257621.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8255992](https://bugs.openjdk.java.net/browse/JDK-8255992): JFR EventWriter does not use first string from StringPool with id 0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/68.diff">https://git.openjdk.java.net/jdk15u-dev/pull/68.diff</a>

</details>
