### PR TITLE
8268635: Corrupt oop in ClassLoaderData

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -793,6 +793,7 @@ void ClassLoaderData::init_handle_locked(OopHandle& dest, Handle h) {
   if (dest.resolve() != NULL) {
     return;
   } else {
+    record_modified_oops();
     dest = _handles.add(h());
   }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8268635](https://bugs.openjdk.java.net/browse/JDK-8268635): Corrupt oop in ClassLoaderData


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/76.diff">https://git.openjdk.java.net/jdk15u-dev/pull/76.diff</a>

</details>
