### PR TITLE
8267652: c2 loop unrolling by 8 results in reading memory past array

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1165,6 +1165,43 @@ class HandlerImpl {
 #endif
 };
 
+inline uint vector_length(const Node* n) {
+  const TypeVect* vt = n->bottom_type()->is_vect();
+  return vt->length();
+}
+
+inline uint vector_length(const MachNode* use, MachOper* opnd) {
+  uint def_idx = use->operand_index(opnd);
+  Node* def = use->in(def_idx);
+  return def->bottom_type()->is_vect()->length();
+}
+
+inline uint vector_length_in_bytes(const Node* n) {
+  const TypeVect* vt = n->bottom_type()->is_vect();
+  return vt->length_in_bytes();
+}
+
+inline uint vector_length_in_bytes(const MachNode* use, MachOper* opnd) {
+  uint def_idx = use->operand_index(opnd);
+  Node* def = use->in(def_idx);
+  return def->bottom_type()->is_vect()->length_in_bytes();
+}
+
+inline Assembler::AvxVectorLen vector_length_encoding(const MachNode* n) {
+  switch(vector_length_in_bytes(n)) {
+    case  4: // fall-through
+    case  8: // fall-through
+    case 16: return Assembler::AVX_128bit;
+    case 32: return Assembler::AVX_256bit;
+    case 64: return Assembler::AVX_512bit;
+
+    default: {
+      ShouldNotReachHere();
+      return Assembler::AVX_NoVec;
+    }
+  }
+}
+
 class Node::PD {
 public:
   enum NodeFlags {
@@ -1819,43 +1856,6 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
 }
 
 void Compile::reshape_address(AddPNode* addp) {
-}
-
-static inline uint vector_length(const MachNode* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->length();
-}
-
-static inline uint vector_length(const MachNode* use, MachOper* opnd) {
-  uint def_idx = use->operand_index(opnd);
-  Node* def = use->in(def_idx);
-  return def->bottom_type()->is_vect()->length();
-}
-
-static inline uint vector_length_in_bytes(const MachNode* n) {
-  const TypeVect* vt = n->bottom_type()->is_vect();
-  return vt->length_in_bytes();
-}
-
-static inline uint vector_length_in_bytes(const MachNode* use, MachOper* opnd) {
-  uint def_idx = use->operand_index(opnd);
-  Node* def = use->in(def_idx);
-  return def->bottom_type()->is_vect()->length_in_bytes();
-}
-
-static inline Assembler::AvxVectorLen vector_length_encoding(const MachNode* n) {
-  switch(vector_length_in_bytes(n)) {
-    case  4: // fall-through
-    case  8: // fall-through
-    case 16: return Assembler::AVX_128bit;
-    case 32: return Assembler::AVX_256bit;
-    case 64: return Assembler::AVX_512bit;
-
-    default: {
-      ShouldNotReachHere();
-      return Assembler::AVX_NoVec;
-    }
-  }
 }
 
 // Helper methods for MachSpillCopyNode::implementation().
@@ -3970,7 +3970,8 @@ instruct vaddB_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vaddB_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVB src (LoadVector mem)));
   format %{ "vpaddb  $dst,$src,$mem\t! add packedB" %}
   ins_encode %{
@@ -4003,7 +4004,8 @@ instruct vaddS_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vaddS_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVS src (LoadVector mem)));
   format %{ "vpaddw  $dst,$src,$mem\t! add packedS" %}
   ins_encode %{
@@ -4037,7 +4039,8 @@ instruct vaddI_reg(vec dst, vec src1, vec src2) %{
 
 
 instruct vaddI_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVI src (LoadVector mem)));
   format %{ "vpaddd  $dst,$src,$mem\t! add packedI" %}
   ins_encode %{
@@ -4070,7 +4073,8 @@ instruct vaddL_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vaddL_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVL src (LoadVector mem)));
   format %{ "vpaddq  $dst,$src,$mem\t! add packedL" %}
   ins_encode %{
@@ -4103,7 +4107,8 @@ instruct vaddF_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vaddF_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVF src (LoadVector mem)));
   format %{ "vaddps  $dst,$src,$mem\t! add packedF" %}
   ins_encode %{
@@ -4136,7 +4141,8 @@ instruct vaddD_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vaddD_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AddVD src (LoadVector mem)));
   format %{ "vaddpd  $dst,$src,$mem\t! add packedD" %}
   ins_encode %{
@@ -4171,7 +4177,8 @@ instruct vsubB_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vsubB_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVB src (LoadVector mem)));
   format %{ "vpsubb  $dst,$src,$mem\t! sub packedB" %}
   ins_encode %{
@@ -4205,7 +4212,8 @@ instruct vsubS_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vsubS_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVS src (LoadVector mem)));
   format %{ "vpsubw  $dst,$src,$mem\t! sub packedS" %}
   ins_encode %{
@@ -4238,7 +4246,8 @@ instruct vsubI_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vsubI_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVI src (LoadVector mem)));
   format %{ "vpsubd  $dst,$src,$mem\t! sub packedI" %}
   ins_encode %{
@@ -4272,7 +4281,8 @@ instruct vsubL_reg(vec dst, vec src1, vec src2) %{
 
 
 instruct vsubL_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVL src (LoadVector mem)));
   format %{ "vpsubq  $dst,$src,$mem\t! sub packedL" %}
   ins_encode %{
@@ -4305,7 +4315,8 @@ instruct vsubF_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vsubF_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVF src (LoadVector mem)));
   format %{ "vsubps  $dst,$src,$mem\t! sub packedF" %}
   ins_encode %{
@@ -4338,7 +4349,8 @@ instruct vsubD_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vsubD_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (SubVD src (LoadVector mem)));
   format %{ "vsubpd  $dst,$src,$mem\t! sub packedD" %}
   ins_encode %{
@@ -4486,7 +4498,8 @@ instruct vmulS_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vmulS_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVS src (LoadVector mem)));
   format %{ "vpmullw $dst,$src,$mem\t! mul packedS" %}
   ins_encode %{
@@ -4520,7 +4533,8 @@ instruct vmulI_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vmulI_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVI src (LoadVector mem)));
   format %{ "vpmulld $dst,$src,$mem\t! mul packedI" %}
   ins_encode %{
@@ -4543,6 +4557,7 @@ instruct vmulL_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vmulL_mem(vec dst, vec src, memory mem) %{
+  predicate(vector_length_in_bytes(n->in(1)) > 8);
   match(Set dst (MulVL src (LoadVector mem)));
   format %{ "vpmullq $dst,$src,$mem\t! mul packedL" %}
   ins_encode %{
@@ -4576,7 +4591,8 @@ instruct vmulF_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vmulF_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVF src (LoadVector mem)));
   format %{ "vmulps  $dst,$src,$mem\t! mul packedF" %}
   ins_encode %{
@@ -4609,7 +4625,8 @@ instruct vmulD_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vmulD_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (MulVD src (LoadVector mem)));
   format %{ "vmulpd  $dst,$src,$mem\t! mul packedD" %}
   ins_encode %{
@@ -4676,7 +4693,8 @@ instruct vdivF_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vdivF_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (DivVF src (LoadVector mem)));
   format %{ "vdivps  $dst,$src,$mem\t! div packedF" %}
   ins_encode %{
@@ -4709,7 +4727,8 @@ instruct vdivD_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vdivD_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (DivVD src (LoadVector mem)));
   format %{ "vdivpd  $dst,$src,$mem\t! div packedD" %}
   ins_encode %{
@@ -4733,6 +4752,7 @@ instruct vsqrtF_reg(vec dst, vec src) %{
 %}
 
 instruct vsqrtF_mem(vec dst, memory mem) %{
+  predicate(vector_length_in_bytes(n->in(1)) > 8);
   match(Set dst (SqrtVF (LoadVector mem)));
   format %{ "vsqrtps  $dst,$mem\t! sqrt packedF" %}
   ins_encode %{
@@ -4756,6 +4776,7 @@ instruct vsqrtD_reg(vec dst, vec src) %{
 %}
 
 instruct vsqrtD_mem(vec dst, memory mem) %{
+  predicate(vector_length_in_bytes(n->in(1)) > 8);
   match(Set dst (SqrtVD (LoadVector mem)));
   format %{ "vsqrtpd  $dst,$mem\t! sqrt packedD" %}
   ins_encode %{
@@ -5041,7 +5062,8 @@ instruct vand_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vand_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (AndV src (LoadVector mem)));
   format %{ "vpand   $dst,$src,$mem\t! and vectors" %}
   ins_encode %{
@@ -5075,7 +5097,8 @@ instruct vor_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vor_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (OrV src (LoadVector mem)));
   format %{ "vpor    $dst,$src,$mem\t! or vectors" %}
   ins_encode %{
@@ -5109,7 +5132,8 @@ instruct vxor_reg(vec dst, vec src1, vec src2) %{
 %}
 
 instruct vxor_mem(vec dst, vec src, memory mem) %{
-  predicate(UseAVX > 0);
+  predicate((UseAVX > 0) &&
+            (vector_length_in_bytes(n->in(1)) > 8));
   match(Set dst (XorV src (LoadVector mem)));
   format %{ "vpxor   $dst,$src,$mem\t! xor vectors" %}
   ins_encode %{
@@ -5249,6 +5273,7 @@ instruct vfmaF_reg(vec a, vec b, vec c) %{
 %}
 
 instruct vfmaF_mem(vec a, memory b, vec c) %{
+  predicate(vector_length_in_bytes(n->in(1)) > 8);
   match(Set c (FmaVF  c (Binary a (LoadVector b))));
   format %{ "fmaps $a,$b,$c\t# $c = $a * $b + $c fma packedF" %}
   ins_cost(150);
@@ -5273,6 +5298,7 @@ instruct vfmaD_reg(vec a, vec b, vec c) %{
 %}
 
 instruct vfmaD_mem(vec a, memory b, vec c) %{
+  predicate(vector_length_in_bytes(n->in(1)) > 8);
   match(Set c (FmaVD  c (Binary a (LoadVector b))));
   format %{ "fmapd $a,$b,$c\t# $c = $a * $b + $c fma packedD" %}
   ins_cost(150);
@@ -5350,6 +5376,7 @@ instruct vpternlog(vec dst, vec src2, vec src3, immU8 func) %{
 %}
 
 instruct vpternlog_mem(vec dst, vec src2, memory src3, immU8 func) %{
+  predicate(vector_length_in_bytes(n->in(1)) > 8);
   match(Set dst (MacroLogicV (Binary dst src2) (Binary (LoadVector src3) func)));
   effect(TEMP dst);
   format %{ "vpternlogd $dst,$src2,$src3,$func\t! vector ternary logic" %}


### PR DESCRIPTION
Please review this backport to jdk15u-dev
it wasn't applying clean due to the miss of 8223347 in 15u
8223347 is too big to be taken into older JDK, hence I took very small part of 8223347 and included into this backport
This small part moves the location of helper funtions ( like vector_length_in_bytes) in x86.ad
and slighlt changes their signature. it's necessary for predicate(vector_length_in_bytes()) construction to work.
testing - tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267652](https://bugs.openjdk.java.net/browse/JDK-8267652): c2 loop unrolling by 8 results in reading memory past array


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/78.diff">https://git.openjdk.java.net/jdk15u-dev/pull/78.diff</a>

</details>
