### PR TITLE
8249588: libwindowsaccessbridge issues on 64bit Windows

### DIFF
--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,7 +168,7 @@ extern "C" {
      * Our window proc
      *
      */
-    BOOL CALLBACK AccessBridgeDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam) {
+    BOOL CALLBACK AccessBridgeDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
         COPYDATASTRUCT *sentToUs;
         char *package;
 

--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.h
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,14 +43,9 @@ extern "C" {
                         LPVOID lpvReserved);
     void AppendToCallOutput(char *s);
     BOOL CALLBACK AccessBridgeDialogProc(HWND hDlg, UINT message,
-                                         UINT wParam, LONG lParam);
+                                         WPARAM wParam, LPARAM lParam);
     HWND getTopLevelHWND(HWND descendent);
 }
-
-LRESULT CALLBACK WinAccessBridgeWindowProc(HWND hWnd, UINT message,
-                                           UINT wParam, LONG lParam);
-
-BOOL CALLBACK DeleteItemProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 
 /**
  * The WinAccessBridge class.  The core of the Windows AT AccessBridge dll


### PR DESCRIPTION
this issue should be fixed here, too. The patch doesn't require adjustments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249588](https://bugs.openjdk.java.net/browse/JDK-8249588): libwindowsaccessbridge issues on 64bit Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/81.diff">https://git.openjdk.java.net/jdk15u-dev/pull/81.diff</a>

</details>
