### PR TITLE
8254967: com.sun.net.HttpsServer spins on TLS session close

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
@@ -430,11 +430,16 @@ class SSLStreams {
             handshaking.lock();
             ByteBuffer tmp = allocate(BufType.APPLICATION);
             WrapperResult r;
+            Status st;
+            HandshakeStatus hs;
             do {
                 tmp.clear();
                 tmp.flip ();
                 r = wrapper.wrapAndSendX (tmp, true);
-            } while (r.result.getStatus() != Status.CLOSED);
+                hs = r.result.getHandshakeStatus();
+                st = r.result.getStatus();
+            } while (st != Status.CLOSED &&
+                        !(st == Status.OK && hs == HandshakeStatus.NOT_HANDSHAKING));
         } finally {
             handshaking.unlock();
         }


### PR DESCRIPTION
Should be ported here, too. No adjustments required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254967](https://bugs.openjdk.java.net/browse/JDK-8254967): com.sun.net.HttpsServer spins on TLS session close


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/83/head:pull/83` \
`$ git checkout pull/83`

Update a local copy of the PR: \
`$ git checkout pull/83` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/83/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 83`

View PR using the GUI difftool: \
`$ git pr show -t 83`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/83.diff">https://git.openjdk.java.net/jdk15u-dev/pull/83.diff</a>

</details>
