### PR TITLE
8261236: C2: ClhsdbJstackXcompStress test fails when StressGCM is enabled

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/compiler/OopMapStream.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/compiler/OopMapStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,24 +29,13 @@ import sun.jvm.hotspot.code.*;
 public class OopMapStream {
   private CompressedReadStream stream;
   private ImmutableOopMap oopMap;
-  private int mask;
   private int size;
   private int position;
   private OopMapValue omv;
   private boolean omvValid;
 
   public OopMapStream(ImmutableOopMap oopMap) {
-    this(oopMap, (OopMapValue.OopTypes[]) null);
-  }
-
-  public OopMapStream(ImmutableOopMap oopMap, OopMapValue.OopTypes type) {
-    this(oopMap, (OopMapValue.OopTypes[]) null);
-    mask = type.getValue();
-  }
-
-  public OopMapStream(ImmutableOopMap oopMap, OopMapValue.OopTypes[] types) {
     stream = new CompressedReadStream(oopMap.getData());
-    mask = computeMask(types);
     size = (int) oopMap.getCount();
     position = 0;
     omv = new OopMapValue();
@@ -72,23 +61,11 @@ public class OopMapStream {
   // Internals only below this point
   //
 
-  private int computeMask(OopMapValue.OopTypes[] types) {
-    mask = 0;
-    if (types != null) {
-      for (int i = 0; i < types.length; i++) {
-        mask |= types[i].getValue();
-      }
-    }
-    return mask;
-  }
-
   private void findNext() {
-    while (position++ < size) {
+    if (position++ < size) {
       omv.readFrom(stream);
-      if ((omv.getType().getValue() & mask) > 0) {
-        omvValid = true;
-        return;
-      }
+      omvValid = true;
+      return;
     }
     omvValid = false;
   }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -1183,7 +1183,8 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       Formatter buf = new Formatter(genHTML);
 
       final class OopMapValueIterator {
-         final Formatter iterate(OopMapStream oms, String type, boolean printContentReg) {
+         final Formatter iterate(OopMapStream oms, String type, boolean printContentReg,
+                                 OopMapValue.OopTypes filter) {
             Formatter tmpBuf = new Formatter(genHTML);
             boolean found = false;
             tmpBuf.beginTag("tr");
@@ -1191,7 +1192,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
             tmpBuf.append(type);
             for (; ! oms.isDone(); oms.next()) {
                OopMapValue omv = oms.getCurrent();
-               if (omv == null) {
+               if (omv == null || omv.getType() != filter) {
                   continue;
                }
                found = true;
@@ -1227,17 +1228,21 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       buf.beginTable(0);
 
       OopMapValueIterator omvIterator = new OopMapValueIterator();
-      OopMapStream oms = new OopMapStream(map, OopMapValue.OopTypes.OOP_VALUE);
-      buf.append(omvIterator.iterate(oms, "Oops:", false));
+      OopMapStream oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "Oops:", false,
+                                     OopMapValue.OopTypes.OOP_VALUE));
 
-      oms = new OopMapStream(map, OopMapValue.OopTypes.NARROWOOP_VALUE);
-      buf.append(omvIterator.iterate(oms, "NarrowOops:", false));
+      oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "NarrowOops:", false,
+                                     OopMapValue.OopTypes.NARROWOOP_VALUE));
 
-      oms = new OopMapStream(map, OopMapValue.OopTypes.CALLEE_SAVED_VALUE);
-      buf.append(omvIterator.iterate(oms, "Callee saved:",  true));
+      oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "Callee saved:", true,
+                                     OopMapValue.OopTypes.CALLEE_SAVED_VALUE));
 
-      oms = new OopMapStream(map, OopMapValue.OopTypes.DERIVED_OOP_VALUE);
-      buf.append(omvIterator.iterate(oms, "Derived oops:", true));
+      oms = new OopMapStream(map);
+      buf.append(omvIterator.iterate(oms, "Derived oops:", true,
+                                     OopMapValue.OopTypes.DERIVED_OOP_VALUE));
 
       buf.endTag("table");
       return buf.toString();


### PR DESCRIPTION
I'd like to backport this fix for SA that reflex changes was made by JDK-8231586 in OopMapValue. The patch applies cleanly. Tested with hotspot/tier1 and by the instruction from bug description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261236](https://bugs.openjdk.java.net/browse/JDK-8261236): C2: ClhsdbJstackXcompStress test fails when StressGCM is enabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/94/head:pull/94` \
`$ git checkout pull/94`

Update a local copy of the PR: \
`$ git checkout pull/94` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/94/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 94`

View PR using the GUI difftool: \
`$ git pr show -t 94`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/94.diff">https://git.openjdk.java.net/jdk15u-dev/pull/94.diff</a>

</details>
