### PR TITLE
8266248: Compilation failure in PLATFORM_API_MacOSX_MidiUtils.c with Xcode 12.5

### DIFF
--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_MidiUtils.c
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_MidiUtils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,9 +255,9 @@ INT32 MIDI_Utils_GetDeviceVersion(int direction, INT32 deviceID, char *name, UIN
 }
 
 
-static MIDIClientRef client = (MIDIClientRef) NULL;
-static MIDIPortRef inPort = (MIDIPortRef) NULL;
-static MIDIPortRef outPort = (MIDIPortRef) NULL;
+static MIDIClientRef client = (MIDIClientRef) 0;
+static MIDIPortRef inPort = (MIDIPortRef) 0;
+static MIDIPortRef outPort = (MIDIPortRef) 0;
 
 // Each MIDIPacket can contain more than one midi messages.
 // This function processes the packet and adds the messages to the specified message queue.
@@ -463,7 +463,7 @@ INT32 MIDI_Utils_OpenDevice(int direction, INT32 deviceID, MacMidiDeviceHandle**
     midiInit();
 
     int err = MIDI_ERROR_NONE;
-    MIDIEndpointRef endpoint = (MIDIEndpointRef) NULL;
+    MIDIEndpointRef endpoint = (MIDIEndpointRef) 0;
 
     TRACE0("MIDI_Utils_OpenDevice\n");
 


### PR DESCRIPTION
Clean backport to jdk15u-dev

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266248](https://bugs.openjdk.java.net/browse/JDK-8266248): Compilation failure in PLATFORM_API_MacOSX_MidiUtils.c with Xcode 12.5


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/98.diff">https://git.openjdk.java.net/jdk15u-dev/pull/98.diff</a>

</details>
