### PR TITLE
8266206: Build failure after JDK-8264752 with older GCCs

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -394,8 +394,9 @@ static julong divide_with_user_unit(Argument& memory_argument, julong value) {
 
 static const char higher_than_msg[] = "This value is higher than the maximum size limited ";
 static const char lower_than_msg[] = "This value is lower than the minimum size required ";
-template <typename Argument, char const *msg>
+template <typename Argument, bool lower>
 static void log_out_of_range_value(Argument& memory_argument, julong min_value) {
+  const char* msg = lower ? lower_than_msg : higher_than_msg;
   if (memory_argument.value()._size != memory_argument.value()._val) {
     // has multiplier
     log_error(arguments) (
@@ -618,7 +619,7 @@ template <typename Argument>
 static bool ensure_gteq(Argument& memory_argument, const jlong value) {
   if ((jlong)memory_argument.value()._size < value) {
     log_set_value(memory_argument);
-    log_out_of_range_value<Argument, lower_than_msg>(memory_argument, value);
+    log_out_of_range_value<Argument, true>(memory_argument, value);
     return false;
   }
   return true;
@@ -653,7 +654,7 @@ template <typename Argument>
 static bool ensure_lteq(Argument& memory_argument, const jlong value) {
   if ((jlong)memory_argument.value()._size > value) {
     log_set_value(memory_argument);
-    log_out_of_range_value<Argument, higher_than_msg>(memory_argument, value);
+    log_out_of_range_value<Argument, false>(memory_argument, value);
     return false;
   }
   return true;


### PR DESCRIPTION
I'd like to backport JDK-8266206 to 15u as follow-up fix for JDK-8264752 that is already included to 15u.
The patch applies cleanly.
Build with GCC 7.5.0 fails without the patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266206](https://bugs.openjdk.java.net/browse/JDK-8266206): Build failure after JDK-8264752 with older GCCs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/110.diff">https://git.openjdk.java.net/jdk15u-dev/pull/110.diff</a>

</details>
