### PR TITLE
8253638: Cleanup os::reserve_memory and remove MAP_FIXED

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1728,7 +1728,7 @@ static void local_sem_init() {
   } else {
     // Memory semaphores must live in shared mem.
     guarantee0(p_sig_msem == NULL);
-    p_sig_msem = (msemaphore*)os::reserve_memory(sizeof(msemaphore), NULL);
+    p_sig_msem = (msemaphore*)os::reserve_memory(sizeof(msemaphore));
     guarantee(p_sig_msem, "Cannot allocate memory for memory semaphore");
     guarantee(::msem_init(p_sig_msem, 0) == p_sig_msem, "msem_init failed");
   }
@@ -2347,19 +2347,7 @@ char *os::scan_pages(char *start, char* end, page_info* page_expected, page_info
 }
 
 // Reserves and attaches a shared memory segment.
-// Will assert if a wish address is given and could not be obtained.
-char* os::pd_reserve_memory(size_t bytes, char* requested_addr, size_t alignment_hint) {
-
-  // All other Unices do a mmap(MAP_FIXED) if the addr is given,
-  // thereby clobbering old mappings at that place. That is probably
-  // not intended, never used and almost certainly an error were it
-  // ever be used this way (to try attaching at a specified address
-  // without clobbering old mappings an alternate API exists,
-  // os::attempt_reserve_memory_at()).
-  // Instead of mimicking the dangerous coding of the other platforms, here I
-  // just ignore the request address (release) or assert(debug).
-  assert0(requested_addr == NULL);
-
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
   // Always round to os::vm_page_size(), which may be larger than 4K.
   bytes = align_up(bytes, os::vm_page_size());
   const size_t alignment_hint0 =
@@ -2368,12 +2356,12 @@ char* os::pd_reserve_memory(size_t bytes, char* requested_addr, size_t alignment
   // In 4K mode always use mmap.
   // In 64K mode allocate small sizes with mmap, large ones with 64K shmatted.
   if (os::vm_page_size() == 4*K) {
-    return reserve_mmaped_memory(bytes, requested_addr, alignment_hint);
+    return reserve_mmaped_memory(bytes, NULL /* requested_addr */, alignment_hint);
   } else {
     if (bytes >= Use64KPagesThreshold) {
-      return reserve_shmated_memory(bytes, requested_addr, alignment_hint);
+      return reserve_shmated_memory(bytes, NULL /* requested_addr */, alignment_hint);
     } else {
-      return reserve_mmaped_memory(bytes, requested_addr, alignment_hint);
+      return reserve_mmaped_memory(bytes, NULL /* requested_addr */, alignment_hint);
     }
   }
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2038,27 +2038,17 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
   return os::uncommit_memory(addr, size);
 }
 
-// If 'fixed' is true, anon_mmap() will attempt to reserve anonymous memory
-// at 'requested_addr'. If there are existing memory mappings at the same
-// location, however, they will be overwritten. If 'fixed' is false,
 // 'requested_addr' is only treated as a hint, the return value may or
 // may not start from the requested address. Unlike Bsd mmap(), this
 // function returns NULL to indicate failure.
-static char* anon_mmap(char* requested_addr, size_t bytes, bool fixed) {
-  char * addr;
-  int flags;
-
-  flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
-  if (fixed) {
-    assert((uintptr_t)requested_addr % os::Bsd::page_size() == 0, "unaligned address");
-    flags |= MAP_FIXED;
-  }
+static char* anon_mmap(char* requested_addr, size_t bytes) {
+  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
+  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might
   // succeed if we have enough swap space to back the physical page.
-  addr = (char*)::mmap(requested_addr, bytes, PROT_NONE,
-                       flags, -1, 0);
+  char* addr = (char*)::mmap(requested_addr, bytes, PROT_NONE, flags, -1, 0);
 
   return addr == MAP_FAILED ? NULL : addr;
 }
@@ -2067,9 +2057,9 @@ static int anon_munmap(char * addr, size_t size) {
   return ::munmap(addr, size) == 0;
 }
 
-char* os::pd_reserve_memory(size_t bytes, char* requested_addr,
-                            size_t alignment_hint) {
-  return anon_mmap(requested_addr, bytes, (requested_addr != NULL));
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
+  // Ignores alignment hint
+  return anon_mmap(NULL /* addr */, bytes);
 }
 
 bool os::pd_release_memory(char* addr, size_t size) {
@@ -2179,7 +2169,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
 
   // Bsd mmap allows caller to pass an address as hint; give it a try first,
   // if kernel honors the hint then we can return immediately.
-  char * addr = anon_mmap(requested_addr, bytes, false);
+  char * addr = anon_mmap(requested_addr, bytes);
   if (addr == requested_addr) {
     return requested_addr;
   }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3574,27 +3574,17 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
   return os::uncommit_memory(addr, size);
 }
 
-// If 'fixed' is true, anon_mmap() will attempt to reserve anonymous memory
-// at 'requested_addr'. If there are existing memory mappings at the same
-// location, however, they will be overwritten. If 'fixed' is false,
 // 'requested_addr' is only treated as a hint, the return value may or
 // may not start from the requested address. Unlike Linux mmap(), this
 // function returns NULL to indicate failure.
-static char* anon_mmap(char* requested_addr, size_t bytes, bool fixed) {
-  char * addr;
-  int flags;
-
-  flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
-  if (fixed) {
-    assert((uintptr_t)requested_addr % os::Linux::page_size() == 0, "unaligned address");
-    flags |= MAP_FIXED;
-  }
+static char* anon_mmap(char* requested_addr, size_t bytes) {
+  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
+  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS;
 
   // Map reserved/uncommitted pages PROT_NONE so we fail early if we
   // touch an uncommitted page. Otherwise, the read/write might
   // succeed if we have enough swap space to back the physical page.
-  addr = (char*)::mmap(requested_addr, bytes, PROT_NONE,
-                       flags, -1, 0);
+  char* addr = (char*)::mmap(requested_addr, bytes, PROT_NONE, flags, -1, 0);
 
   return addr == MAP_FAILED ? NULL : addr;
 }
@@ -3607,19 +3597,14 @@ static char* anon_mmap(char* requested_addr, size_t bytes, bool fixed) {
 //     It must be a multiple of allocation granularity.
 // Returns address of memory or NULL. If req_addr was not NULL, will only return
 //  req_addr or NULL.
-static char* anon_mmap_aligned(size_t bytes, size_t alignment, char* req_addr) {
-
+static char* anon_mmap_aligned(char* req_addr, size_t bytes, size_t alignment) {
   size_t extra_size = bytes;
   if (req_addr == NULL && alignment > 0) {
     extra_size += alignment;
   }
 
-  char* start = (char*) ::mmap(req_addr, extra_size, PROT_NONE,
-    MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE,
-    -1, 0);
-  if (start == MAP_FAILED) {
-    start = NULL;
-  } else {
+  char* start = anon_mmap(req_addr, bytes);
+  if (start != NULL) {
     if (req_addr != NULL) {
       if (start != req_addr) {
         ::munmap(start, extra_size);
@@ -3645,9 +3630,9 @@ static int anon_munmap(char * addr, size_t size) {
   return ::munmap(addr, size) == 0;
 }
 
-char* os::pd_reserve_memory(size_t bytes, char* requested_addr,
-                            size_t alignment_hint) {
-  return anon_mmap(requested_addr, bytes, (requested_addr != NULL));
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
+  // Ignores alignment hint
+  return anon_mmap(NULL, bytes);
 }
 
 bool os::pd_release_memory(char* addr, size_t size) {
@@ -3996,7 +3981,7 @@ static char* shmat_with_alignment(int shmid, size_t bytes, size_t alignment) {
   // To ensure that we get 'alignment' aligned memory from shmat,
   // we pre-reserve aligned virtual memory and then attach to that.
 
-  char* pre_reserved_addr = anon_mmap_aligned(bytes, alignment, NULL);
+  char* pre_reserved_addr = anon_mmap_aligned(NULL /* req_addr */, bytes, alignment);
   if (pre_reserved_addr == NULL) {
     // Couldn't pre-reserve aligned memory.
     shm_warning("Failed to pre-reserve aligned memory for shmat.");
@@ -4165,7 +4150,7 @@ char* os::Linux::reserve_memory_special_huge_tlbfs_mixed(size_t bytes,
   assert(is_aligned(bytes, alignment), "Must be");
 
   // First reserve - but not commit - the address range in small pages.
-  char* const start = anon_mmap_aligned(bytes, alignment, req_addr);
+  char* const start = anon_mmap_aligned(req_addr, bytes, alignment);
 
   if (start == NULL) {
     return NULL;
@@ -4345,7 +4330,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
 
   // Linux mmap allows caller to pass an address as hint; give it a try first,
   // if kernel honors the hint then we can return immediately.
-  char * addr = anon_mmap(requested_addr, bytes, false);
+  char * addr = anon_mmap(requested_addr, bytes);
   if (addr == requested_addr) {
     return requested_addr;
   }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -324,7 +324,7 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
       MemTracker::record_virtual_memory_reserve((address)extra_base, extra_size, CALLER_PC);
     }
   } else {
-    extra_base = os::reserve_memory(extra_size, NULL, alignment);
+    extra_base = os::reserve_memory(extra_size, alignment);
   }
 
   if (extra_base == NULL) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3091,8 +3091,8 @@ void os::split_reserved_memory(char *base, size_t size, size_t split) {
   assert(is_aligned(split_address, os::vm_allocation_granularity()), "Sanity");
 
   release_memory(base, size);
-  reserve_memory(split, base);
-  reserve_memory(size - split, split_address);
+  attempt_reserve_memory_at(split, base);
+  attempt_reserve_memory_at(size - split, split_address);
 
   // NMT: nothing to do here. Since Windows implements the split by
   //  releasing and re-reserving memory, the parts are already registered
@@ -3114,7 +3114,7 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
   char* aligned_base = NULL;
 
   do {
-    char* extra_base = os::reserve_memory(extra_size, NULL, alignment, file_desc);
+    char* extra_base = os::reserve_memory_with_fd(extra_size, alignment, file_desc);
     if (extra_base == NULL) {
       return NULL;
     }
@@ -3127,14 +3127,21 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
       os::release_memory(extra_base, extra_size);
     }
 
-    aligned_base = os::reserve_memory(size, aligned_base, 0, file_desc);
+    aligned_base = os::attempt_reserve_memory_at(size, aligned_base, file_desc);
 
   } while (aligned_base == NULL);
 
   return aligned_base;
 }
 
-char* os::pd_reserve_memory(size_t bytes, char* addr, size_t alignment_hint) {
+char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
+  // Ignores alignment hint
+  return pd_attempt_reserve_memory_at(bytes, NULL /* addr */);
+}
+
+// Reserve memory at an arbitrary address, only if that area is
+// available (and not reserved for something else).
+char* os::pd_attempt_reserve_memory_at(size_t bytes, char* addr) {
   assert((size_t)addr % os::vm_allocation_granularity() == 0,
          "reserve alignment");
   assert(bytes % os::vm_page_size() == 0, "reserve page size");
@@ -3163,14 +3170,6 @@ char* os::pd_reserve_memory(size_t bytes, char* addr, size_t alignment_hint) {
          "Unexpected address from reserve.");
 
   return res;
-}
-
-// Reserve memory at an arbitrary address, only if that area is
-// available (and not reserved for something else).
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
-  // Windows os::reserve_memory() fails of the requested address range is
-  // not avilable.
-  return reserve_memory(bytes, requested_addr);
 }
 
 char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -819,7 +819,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -248,7 +248,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -675,7 +675,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -274,7 +274,7 @@ bool os::is_allocatable(size_t bytes) {
     return true;
   }
 
-  char* addr = reserve_memory(bytes, NULL);
+  char* addr = reserve_memory(bytes);
 
   if (addr != NULL) {
     release_memory(addr, bytes);

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -43,7 +43,7 @@ ZMarkStackSpace::ZMarkStackSpace() :
   // Reserve address space
   const size_t size = ZMarkStackSpaceLimit;
   const size_t alignment = (size_t)os::vm_allocation_granularity();
-  const uintptr_t addr = (uintptr_t)os::reserve_memory(size, NULL, alignment, mtGC);
+  const uintptr_t addr = (uintptr_t)os::reserve_memory(size, alignment, mtGC);
   if (addr == 0) {
     log_error_pd(gc, marking)("Failed to reserve address space for mark stacks");
     return;

--- a/src/hotspot/share/memory/allocation.inline.hpp
+++ b/src/hotspot/share/memory/allocation.inline.hpp
@@ -58,7 +58,7 @@ E* MmapArrayAllocator<E>::allocate_or_null(size_t length, MEMFLAGS flags) {
   size_t size = size_for(length);
   int alignment = os::vm_allocation_granularity();
 
-  char* addr = os::reserve_memory(size, NULL, alignment, flags);
+  char* addr = os::reserve_memory(size, alignment, flags);
   if (addr == NULL) {
     return NULL;
   }
@@ -76,7 +76,7 @@ E* MmapArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
   size_t size = size_for(length);
   int alignment = os::vm_allocation_granularity();
 
-  char* addr = os::reserve_memory(size, NULL, alignment, flags);
+  char* addr = os::reserve_memory(size, alignment, flags);
   if (addr == NULL) {
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "Allocator (reserve)");
   }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -192,7 +192,7 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
         base = NULL;
       }
     } else {
-      base = os::reserve_memory(size, NULL, alignment, _fd_for_heap);
+      base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
     }
 
     if (base == NULL) return;
@@ -380,7 +380,7 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
     if (requested_address != 0) {
       base = os::attempt_reserve_memory_at(size, requested_address, _fd_for_heap);
     } else {
-      base = os::reserve_memory(size, NULL, alignment, _fd_for_heap);
+      base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
     }
   }
   if (base == NULL) { return; }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1481,7 +1481,7 @@ WB_ENTRY(void, WB_ReadReservedMemory(JNIEnv* env, jobject o))
   static char c;
   static volatile char* p;
 
-  p = os::reserve_memory(os::vm_allocation_granularity(), NULL, 0);
+  p = os::reserve_memory(os::vm_allocation_granularity());
   if (p == NULL) {
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "Failed to reserve memory");
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1653,32 +1653,33 @@ bool os::create_stack_guard_pages(char* addr, size_t bytes) {
   return os::pd_create_stack_guard_pages(addr, bytes);
 }
 
-char* os::reserve_memory(size_t bytes, char* addr, size_t alignment_hint, int file_desc) {
-  char* result = NULL;
-
-  if (file_desc != -1) {
-    // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
-    // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
-    result = os::map_memory_to_file(addr, bytes, file_desc);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC);
-    }
-  } else {
-    result = pd_reserve_memory(bytes, addr, alignment_hint);
-    if (result != NULL) {
-      MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
+char* os::reserve_memory(size_t bytes, size_t alignment_hint, MEMFLAGS flags) {
+  char* result = pd_reserve_memory(bytes, alignment_hint);
+  if (result != NULL) {
+    MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC);
+    if (flags != mtOther) {
+      MemTracker::record_virtual_memory_type(result, flags);
     }
   }
 
   return result;
 }
 
-char* os::reserve_memory(size_t bytes, char* addr, size_t alignment_hint,
-   MEMFLAGS flags) {
-  char* result = pd_reserve_memory(bytes, addr, alignment_hint);
-  if (result != NULL) {
-    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
-    MemTracker::record_virtual_memory_type((address)result, flags);
+char* os::reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_desc) {
+  char* result;
+
+  if (file_desc != -1) {
+    // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
+    // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
+    result = os::map_memory_to_file(NULL /* addr */, bytes, file_desc);
+    if (result != NULL) {
+      MemTracker::record_virtual_memory_reserve_and_commit(result, bytes, CALLER_PC);
+    }
+  } else {
+    result = pd_reserve_memory(bytes, alignment_hint);
+    if (result != NULL) {
+      MemTracker::record_virtual_memory_reserve(result, bytes, CALLER_PC);
+    }
   }
 
   return result;

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -115,10 +115,11 @@ class os: AllStatic {
     _page_sizes[1] = 0; // sentinel
   }
 
-  static char*  pd_reserve_memory(size_t bytes, char* addr = 0,
-                                  size_t alignment_hint = 0);
+  static char*  pd_reserve_memory(size_t bytes, size_t alignment_hint);
+
   static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr);
   static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc);
+
   static bool   pd_commit_memory(char* addr, size_t bytes, bool executable);
   static bool   pd_commit_memory(char* addr, size_t size, size_t alignment_hint,
                                  bool executable);
@@ -312,13 +313,21 @@ class os: AllStatic {
                                                   const size_t size);
 
   static int    vm_allocation_granularity();
-  static char*  reserve_memory(size_t bytes, char* addr = 0,
-                               size_t alignment_hint = 0, int file_desc = -1);
-  static char*  reserve_memory(size_t bytes, char* addr,
-                               size_t alignment_hint, MEMFLAGS flags);
-  static char*  reserve_memory_aligned(size_t size, size_t alignment, int file_desc = -1);
-  static char*  attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc = -1);
 
+  // Reserves virtual memory.
+  // alignment_hint - currently only used by AIX
+  static char*  reserve_memory(size_t bytes, size_t alignment_hint = 0, MEMFLAGS flags = mtOther);
+
+  // Reserves virtual memory.
+  // if file_desc != -1, also attaches the memory to the file.
+  static char*  reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_desc);
+
+  // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
+  static char*  reserve_memory_aligned(size_t size, size_t alignment, int file_desc = -1);
+
+  // Attempts to reserve the virtual memory at [addr, addr + bytes).
+  // Does not overwrite existing mappings.
+  static char*  attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc = -1);
 
   // Split a reserved memory region [base, base+size) into two regions [base, base+split) and
   //  [base+split, base+size).

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -47,7 +47,7 @@ void SafepointMechanism::default_initialize() {
     // Polling page
     const size_t page_size = os::vm_page_size();
     const size_t allocation_size = 2 * page_size;
-    char* polling_page = os::reserve_memory(allocation_size, NULL, page_size);
+    char* polling_page = os::reserve_memory(allocation_size, page_size);
     os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page");
     MemTracker::record_virtual_memory_type((address)polling_page, mtSafepoint);
 

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -101,7 +101,7 @@ public:
   static void test_committed_region_impl(size_t num_pages, size_t touch_pages, int* page_num) {
     const size_t page_sz = os::vm_page_size();
     const size_t size = num_pages * page_sz;
-    char* base = os::reserve_memory(size, NULL, page_sz, mtThreadStack);
+    char* base = os::reserve_memory(size, page_sz, mtThreadStack);
     bool result = os::commit_memory(base, size, false);
     size_t index;
     ASSERT_NE(base, (char*)NULL);
@@ -169,7 +169,7 @@ public:
     const size_t page_sz = os::vm_page_size();
     const size_t num_pages = 4;
     const size_t size = num_pages * page_sz;
-    char* base = os::reserve_memory(size, NULL, page_sz, mtTest);
+    char* base = os::reserve_memory(size, page_sz, mtTest);
     ASSERT_NE(base, (char*)NULL);
     result = os::commit_memory(base, size, false);
 


### PR DESCRIPTION
This backport is a part of MacOS/aarch64 support backport. It is needed to backport [JDK-8234930](https://bugs.openjdk.java.net/browse/JDK-8234930). 

It has been tested (tier1) on Linux x64 and x86, on Windows x64 and on MacOS x64 (https://github.com/KaperD/jdk15u-dev/actions/runs/1399380363)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253638](https://bugs.openjdk.java.net/browse/JDK-8253638): Cleanup os::reserve_memory and remove MAP_FIXED


### Reviewers
 * [Anton Kozlov](https://openjdk.java.net/census#akozlov) (@AntonKozlov - no project role)
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/125.diff">https://git.openjdk.java.net/jdk15u-dev/pull/125.diff</a>

</details>
