### PR TITLE
8254270: linux 32 bit build doesn't compile libjdwp/log_messages.c

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,12 @@ get_time_stamp(char *tbuf, size_t ltbuf)
                 "%d.%m.%Y %T", localtime(&t));
     (void)strftime(timestamp_timezone, TZ_SIZE,
                 "%Z", localtime(&t));
-    (void)snprintf(tbuf, ltbuf,
-                   "%s.%.3d %s", timestamp_date_time,
-                   (int)(millisecs), timestamp_timezone);
+
+    // Truncate milliseconds in buffer large enough to hold the
+    // value which is always < 1000 (and so a maximum of 3 digits for "%.3d")
+    char tmp[20];
+    snprintf(tmp, sizeof(tmp), "%.3d", millisecs);
+    snprintf(tbuf, ltbuf, "%s.%.3s %s", timestamp_date_time, tmp, timestamp_timezone);
 }
 
 /* Get basename of filename */


### PR DESCRIPTION
Clean backport that fixes Linux 32-bit build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8254270](https://bugs.openjdk.java.net/browse/JDK-8254270): linux 32 bit build doesn't compile libjdwp/log_messages.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/137/head:pull/137` \
`$ git checkout pull/137`

Update a local copy of the PR: \
`$ git checkout pull/137` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 137`

View PR using the GUI difftool: \
`$ git pr show -t 137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/137.diff">https://git.openjdk.java.net/jdk15u-dev/pull/137.diff</a>

</details>
