### PR TITLE
8250605: Linux x86_32 builds fail after JDK-8249821

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -563,7 +563,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
     WARNINGS_AS_ERRORS_xlc := false, \
-    DISABLED_WARNINGS_gcc := sign-compare unused-function, \
+    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast, \
     DISABLED_WARNINGS_clang := sign-compare, \
     DISABLED_WARNINGS_microsoft := 4018 4146 4244 4996, \
     LDFLAGS := $(subst -Xlinker -z -Xlinker defs,, \


### PR DESCRIPTION
Clean backport. Followup to JDK-8249821.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8250605](https://bugs.openjdk.java.net/browse/JDK-8250605): Linux x86_32 builds fail after JDK-8249821


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/139.diff">https://git.openjdk.java.net/jdk15u-dev/pull/139.diff</a>

</details>
