### PR TITLE
8255790: GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -434,91 +434,48 @@ endif
 
 ###########################################################################
 
+
 ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
-  LIBHARFBUZZ_LIBS := $(HARFBUZZ_LIBS)
+   LIBFONTMANAGER_EXTRA_SRC =
+   BUILD_LIBFONTMANAGER_FONTLIB += $(HARFBUZZ_LIBS)
 else
-  HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
+   LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
+   HARFBUZZ_CFLAGS := -DHAVE_OT -DHAVE_FALLBACK -DHAVE_UCDN -DHAVE_ROUND
 
-  # This is better than adding EXPORT_ALL_SYMBOLS
-  ifneq ($(filter $(TOOLCHAIN_TYPE), gcc clang), )
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__attribute__\(\(visibility\(\"default\"\)\)\)
-  else ifeq ($(TOOLCHAIN_TYPE), microsoft)
-    HARFBUZZ_CFLAGS += -DHB_EXTERN=__declspec\(dllexport\)
-  endif
+   ifeq ($(call isTargetOs, windows), false)
+     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
+                        -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
+                        -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
+   endif
+   ifeq ($(call isTargetOs, linux macosx), true)
+     HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES
+   endif
+   ifeq ($(call isTargetOs, macosx), true)
+     HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
+   endif
 
-  ifeq ($(call isTargetOs, windows), false)
-    HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
-                      -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
-                      -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
-  endif
-  ifeq ($(call isTargetOs, linux macosx), true)
-    HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES
-  endif
-  ifeq ($(call isTargetOs, macosx), true)
-    HARFBUZZ_CFLAGS += -DHAVE_CORETEXT
-  endif
-  ifeq ($(call isTargetOs, macosx), false)
-    LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-coretext.cc
-  endif
-  # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-  LIBHARFBUZZ_EXCLUDE_FILES += harfbuzz/hb-ft.cc
+   ifeq ($(call isTargetOs, macosx), false)
+     LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-coretext.cc
+   endif
+   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
+   LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
 
-  LIBHARFBUZZ_CFLAGS += $(HARFBUZZ_CFLAGS)
-
-  # For use by libfontmanager:
-  ifeq ($(call isTargetOs, windows), true)
-    LIBHARFBUZZ_LIBS := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libharfbuzz/harfbuzz.lib
-  else
-    LIBHARFBUZZ_LIBS := -lharfbuzz
-  endif
-
-  LIBHARFBUZZ_EXTRA_HEADER_DIRS := \
-    libharfbuzz/hb-ucdn \
-    #
-
-  LIBHARFBUZZ_OPTIMIZATION := HIGH
-
-  LIBHARFBUZZ_CFLAGS += $(X_CFLAGS) -DLE_STANDALONE -DHEADLESS
-
-  $(eval $(call SetupJdkLibrary, BUILD_LIBHARFBUZZ, \
-      NAME := harfbuzz, \
-      EXCLUDE_FILES := $(LIBHARFBUZZ_EXCLUDE_FILES), \
-      TOOLCHAIN := TOOLCHAIN_LINK_CXX, \
-      CFLAGS := $(CFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      CXXFLAGS := $(CXXFLAGS_JDKLIB) $(LIBHARFBUZZ_CFLAGS), \
-      OPTIMIZATION := $(LIBHARFBUZZ_OPTIMIZATION), \
-      CFLAGS_windows = -DCC_NOEX, \
-      EXTRA_HEADER_DIRS := $(LIBHARFBUZZ_EXTRA_HEADER_DIRS), \
-      WARNINGS_AS_ERRORS_xlc := false, \
-      DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing, \
-      DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
-        maybe-uninitialized class-memaccess, \
-      DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
+   HARFBUZZ_DISABLED_WARNINGS_gcc := type-limits missing-field-initializers strict-aliasing
+   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := reorder delete-non-virtual-dtor strict-overflow \
+        maybe-uninitialized class-memaccess
+   HARFBUZZ_DISABLED_WARNINGS_clang := unused-value incompatible-pointer-types \
         tautological-constant-out-of-range-compare int-to-pointer-cast \
-        undef missing-field-initializers, \
-      DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138, \
-      LDFLAGS := $(LDFLAGS_JDKLIB) \
-        $(call SET_SHARED_LIBRARY_ORIGIN), \
-      LDFLAGS_unix := -L$(INSTALL_LIBRARIES_HERE), \
-      LDFLAGS_aix := -Wl$(COMMA)-berok, \
-      LIBS := $(BUILD_LIBHARFBUZZ), \
-      LIBS_unix := $(LIBM) $(LIBCXX), \
-      LIBS_macosx := -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
-      LIBS_windows := user32.lib, \
-  ))
+        undef missing-field-initializers
+   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244 4090 4146 4334 4819 4101 4068 4805 4138
 
-  ifeq ($(FREETYPE_TO_USE), bundled)
-    $(BUILD_LIBHARFBUZZ): $(BUILD_LIBFREETYPE)
-  endif
-
-  TARGETS += $(BUILD_LIBHARFBUZZ)
+   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 
 endif
 
-###########################################################################
 
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libharfbuzz \
+    libharfbuzz/hb-ucdn \
     common/awt \
     common/font \
     libawt/java2d \
@@ -526,10 +483,10 @@ LIBFONTMANAGER_EXTRA_HEADER_DIRS := \
     libawt/java2d/loops \
     #
 
-LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS) $(HARFBUZZ_FLAGS)
-BUILD_LIBFONTMANAGER_FONTLIB += $(LIBHARFBUZZ_LIBS) $(LIBFREETYPE_LIBS)
+LIBFONTMANAGER_CFLAGS += $(LIBFREETYPE_CFLAGS)
+BUILD_LIBFONTMANAGER_FONTLIB +=  $(LIBFREETYPE_LIBS)
 
-LIBFONTMANAGER_OPTIMIZATION := HIGH
+LIBFONTMANAGER_OPTIMIZATION := HIGHEST
 
 ifeq ($(call isTargetOs, windows), true)
   LIBFONTMANAGER_EXCLUDE_FILES += X11FontScaler.c \
@@ -567,10 +524,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     OPTIMIZATION := $(LIBFONTMANAGER_OPTIMIZATION), \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
+    EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \
     WARNINGS_AS_ERRORS_xlc := false, \
-    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast, \
-    DISABLED_WARNINGS_clang := sign-compare, \
-    DISABLED_WARNINGS_microsoft := 4018 4146 4244 4996, \
+    DISABLED_WARNINGS_gcc := sign-compare unused-function int-to-pointer-cast $(HARFBUZZ_DISABLED_WARNINGS_gcc), \
+    DISABLED_WARNINGS_CXX_gcc := $(HARFBUZZ_DISABLED_WARNINGS_CXX_gcc), \
+    DISABLED_WARNINGS_clang := sign-compare $(HARFBUZZ_DISABLED_WARNINGS_clang), \
+    DISABLED_WARNINGS_microsoft := 4018 4996 $(HARFBUZZ_DISABLED_WARNINGS_microsoft), \
     LDFLAGS := $(subst -Xlinker -z -Xlinker defs,, \
         $(subst -Wl$(COMMA)-z$(COMMA)defs,,$(LDFLAGS_JDKLIB))) $(LDFLAGS_CXX_JDK) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
@@ -578,16 +537,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     LDFLAGS_aix := -Wl$(COMMA)-berok, \
     LIBS := $(BUILD_LIBFONTMANAGER_FONTLIB), \
     LIBS_unix := -lawt -ljava -ljvm $(LIBM) $(LIBCXX), \
-    LIBS_macosx := -lawt_lwawt, \
+    LIBS_macosx := -lawt_lwawt -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
     LIBS_windows := $(WIN_JAVA_LIB) advapi32.lib user32.lib gdi32.lib \
         $(WIN_AWT_LIB), \
 ))
 
 $(BUILD_LIBFONTMANAGER): $(BUILD_LIBAWT)
-
-ifeq ($(USE_EXTERNAL_HARFBUZZ), false)
-  $(BUILD_LIBFONTMANAGER): $(BUILD_LIBHARFBUZZ)
-endif
 
 ifeq ($(call isTargetOs, macosx), true)
   $(BUILD_LIBFONTMANAGER): $(call FindLib, $(MODULE), awt_lwawt)


### PR DESCRIPTION
Follow up for JDK-8249821: Separate libharfbuzz from libfontmanager

The original patch doesn't apply cleanly. Applied it manually without implicit including parts of other patches for [1]/[2]/[3] that aren't currently in jdk15u. Also, [4] was included as a part of this patch. So the backport for jdk15u should be very similar to the backport for jdk11u.

Tested with the reproducer for JDK-8272149 (fails without the fix, passes with the fix).

[1] JDK-8258484: AIX build fails in Harfbuzz with XLC 16.01.0000.0006
[2] JDK-8074844: Resolve disabled warnings for libfontmanager
[3] JDK-8247872: Upgrade HarfBuzz to the latest 2.7.2
[4] JDK-8272332: --with-harfbuzz=system doesn't add -lharfbuzz after JDK-8255790

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8255790](https://bugs.openjdk.java.net/browse/JDK-8255790): GTKL&F: Java 16 crashes on initialising GTKL&F on Manjaro Linux
 * [JDK-8272332](https://bugs.openjdk.java.net/browse/JDK-8272332): --with-harfbuzz=system doesn't add -lharfbuzz after JDK-8255790


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/143.diff">https://git.openjdk.java.net/jdk15u-dev/pull/143.diff</a>

</details>
