### PR TITLE
8268620: InfiniteLoopException test may fail on x86 platforms

### DIFF
--- a/test/jdk/java/awt/Robot/InfiniteLoopException.java
+++ b/test/jdk/java/awt/Robot/InfiniteLoopException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ public final class InfiniteLoopException {
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
             test(frame);
+            frame.setVisible(false);
         } finally {
             frame.dispose();
         }
@@ -49,6 +50,7 @@ public final class InfiniteLoopException {
         Runnable repaint = () -> {
             while (frame.isDisplayable()) {
                 frame.repaint();
+                Thread.yield();
             }
         };
         new Thread(repaint).start();


### PR DESCRIPTION
Clean backport of a test fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268620](https://bugs.openjdk.java.net/browse/JDK-8268620): InfiniteLoopException test may fail on x86 platforms


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/145/head:pull/145` \
`$ git checkout pull/145`

Update a local copy of the PR: \
`$ git checkout pull/145` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 145`

View PR using the GUI difftool: \
`$ git pr show -t 145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/145.diff">https://git.openjdk.java.net/jdk15u-dev/pull/145.diff</a>

</details>
