### PR TITLE
Backport 6d8acd2696f41918d4233ddffe46e6c205f9dbc3

### DIFF
--- a/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
+++ b/test/jdk/java/lang/invoke/ConstantIdentityMHTest.java
@@ -59,8 +59,7 @@ public class ConstantIdentityMHTest {
         assertEquals(MethodHandles.zero(expectedtype).type().toString(), expected);
     }
 
-    @Test
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(expectedExceptions={ NullPointerException.class })
     public void testZeroNPE() {
         MethodHandle mh = MethodHandles.zero(null);
     }
@@ -73,8 +72,7 @@ public class ConstantIdentityMHTest {
         assertEquals((String)mhEmpty.invoke("x","y"), null);
     }
 
-    @Test
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(expectedExceptions = { NullPointerException.class })
     void testEmptyNPE() {
         MethodHandle lenEmptyMH = MethodHandles.empty(null);
     }

--- a/test/jdk/java/lang/invoke/DropArgumentsTest.java
+++ b/test/jdk/java/lang/invoke/DropArgumentsTest.java
@@ -65,8 +65,7 @@ public class DropArgumentsTest {
         };
     }
 
-    @Test(dataProvider = "dropArgumentsToMatchNPEData")
-    @ExpectedExceptions(NullPointerException.class)
+    @Test(dataProvider = "dropArgumentsToMatchNPEData", expectedExceptions = { NullPointerException.class })
     public void dropArgumentsToMatchNPE(MethodHandle target, int pos, List<Class<?>> valueType, int skip) {
         MethodHandles.dropArgumentsToMatch(target, pos, valueType , skip);
     }
@@ -85,14 +84,12 @@ public class DropArgumentsTest {
         };
     }
 
-    @Test(dataProvider = "dropArgumentsToMatchIAEData")
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(dataProvider = "dropArgumentsToMatchIAEData", expectedExceptions = { IllegalArgumentException.class })
     public void dropArgumentsToMatchIAE(MethodHandle target, int pos, List<Class<?>> valueType, int skip) {
         MethodHandles.dropArgumentsToMatch(target, pos, valueType , skip);
     }
 
-    @Test
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void dropArgumentsToMatchTestWithVoid() throws Throwable {
         MethodHandle cat = lookup().findVirtual(String.class, "concat",
                                    MethodType.methodType(String.class, String.class));

--- a/test/jdk/java/lang/invoke/VarArgsTest.java
+++ b/test/jdk/java/lang/invoke/VarArgsTest.java
@@ -69,8 +69,7 @@ public class VarArgsTest {
         assertEquals("[two, too]", asListWithVarargs.invoke("two", "too").toString());
     }
 
-    @Test
-    @ExpectedExceptions(IllegalArgumentException.class)
+    @Test(expectedExceptions = { IllegalArgumentException.class })
     public void testWithVarargsIAE() throws Throwable {
         MethodHandle lenMH = publicLookup()
             .findVirtual(String.class, "length", methodType(int.class));


### PR DESCRIPTION
Three tests fixed for newer TestNG. Works now with latest jtreg as well as jtreg 5.1