### PR TITLE
8226810: Failed to launch JVM because of NullPointerException occured on System.props

### DIFF
--- a/make/data/charsetmapping/stdcs-windows
+++ b/make/data/charsetmapping/stdcs-windows
@@ -2,6 +2,7 @@
 #   generate these charsets into sun.nio.cs
 #
 GBK
+GB18030
 Johab
 MS1255
 MS1256


### PR DESCRIPTION
One-liner fix to include GB18030 into java.base on Windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226810](https://bugs.openjdk.java.net/browse/JDK-8226810): Failed to launch JVM because of NullPointerException occured on System.props


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/152.diff">https://git.openjdk.java.net/jdk15u-dev/pull/152.diff</a>

</details>
