### PR TITLE
8253639: Change os::attempt_reserve_memory_at parameter order

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2532,7 +2532,7 @@ bool os::can_execute_large_page_memory() {
   return false;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
   char* result = NULL;
 
@@ -2550,7 +2550,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int f
 
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes) {
   char* addr = NULL;
 
   // Always round to os::vm_page_size(), which may be larger than 4K.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2142,9 +2142,9 @@ bool os::can_execute_large_page_memory() {
   return false;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
-  char* result = pd_attempt_reserve_memory_at(bytes, requested_addr);
+  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes);
   if (result != NULL) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
       vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
@@ -2156,7 +2156,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int f
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes) {
   // Assert only that the size is a multiple of the page size, since
   // that's all that mmap requires, and since that's all we really know
   // about at this low abstraction level.  If we need higher alignment,

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4303,9 +4303,9 @@ bool os::can_execute_large_page_memory() {
   return UseTransparentHugePages || UseHugeTLBFS;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
-  char* result = pd_attempt_reserve_memory_at(bytes, requested_addr);
+  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes);
   if (result != NULL) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
       vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
@@ -4317,7 +4317,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int f
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes) {
   // Assert only that the size is a multiple of the page size, since
   // that's all that mmap requires, and since that's all we really know
   // about at this low abstraction level.  If we need higher alignment,

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3091,8 +3091,8 @@ void os::split_reserved_memory(char *base, size_t size, size_t split) {
   assert(is_aligned(split_address, os::vm_allocation_granularity()), "Sanity");
 
   release_memory(base, size);
-  attempt_reserve_memory_at(split, base);
-  attempt_reserve_memory_at(size - split, split_address);
+  attempt_reserve_memory_at(base, split);
+  attempt_reserve_memory_at(split_address, size - split);
 
   // NMT: nothing to do here. Since Windows implements the split by
   //  releasing and re-reserving memory, the parts are already registered
@@ -3127,7 +3127,7 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
       os::release_memory(extra_base, extra_size);
     }
 
-    aligned_base = os::attempt_reserve_memory_at(size, aligned_base, file_desc);
+    aligned_base = os::attempt_reserve_memory_at(aligned_base, size, file_desc);
 
   } while (aligned_base == NULL);
 
@@ -3136,12 +3136,12 @@ char* os::reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
 
 char* os::pd_reserve_memory(size_t bytes, size_t alignment_hint) {
   // Ignores alignment hint
-  return pd_attempt_reserve_memory_at(bytes, NULL /* addr */);
+  return pd_attempt_reserve_memory_at(NULL /* addr */, bytes);
 }
 
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* addr) {
+char* os::pd_attempt_reserve_memory_at(char* addr, size_t bytes) {
   assert((size_t)addr % os::vm_allocation_granularity() == 0,
          "reserve alignment");
   assert(bytes % os::vm_page_size() == 0, "reserve page size");
@@ -3172,7 +3172,7 @@ char* os::pd_attempt_reserve_memory_at(size_t bytes, char* addr) {
   return res;
 }
 
-char* os::pd_attempt_reserve_memory_at(size_t bytes, char* requested_addr, int file_desc) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, int file_desc) {
   assert(file_desc >= 0, "file_desc is not valid");
   return map_memory_to_file(requested_addr, bytes, file_desc);
 }

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -884,7 +884,7 @@ void os::workaround_expand_exec_shield_cs_limit() {
    */
   char* hint = (char*)(Linux::initial_thread_stack_bottom() -
                        (JavaThread::stack_guard_zone_size() + page_size));
-  char* codebuf = os::attempt_reserve_memory_at(page_size, hint);
+  char* codebuf = os::attempt_reserve_memory_at(hint, page_size);
 
   if (codebuf == NULL) {
     // JDK-8197429: There may be a stack gap of one megabyte between
@@ -892,7 +892,7 @@ void os::workaround_expand_exec_shield_cs_limit() {
     // Linux kernel workaround for CVE-2017-1000364.  If we failed to
     // map our codebuf, try again at an address one megabyte lower.
     hint -= 1 * M;
-    codebuf = os::attempt_reserve_memory_at(page_size, hint);
+    codebuf = os::attempt_reserve_memory_at(hint, page_size);
   }
 
   if ((codebuf == NULL) || (!os::commit_memory(codebuf, page_size, true))) {

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -220,7 +220,7 @@ static bool map_nvdimm_space(ReservedSpace rs) {
     return false;
   }
   // commit this memory in nv-dimm
-  char* ret = os::attempt_reserve_memory_at(rs.size(), rs.base(), _backing_fd);
+  char* ret = os::attempt_reserve_memory_at(rs.base(), rs.size(), _backing_fd);
 
   if (ret != rs.base()) {
     if (ret != NULL) {
@@ -267,7 +267,7 @@ bool G1RegionToHeteroSpaceMapper::initialize() {
   assert(rs_dram.size() == rs_nvdimm.size() && rs_nvdimm.size() == MaxHeapSize, "They all should be same");
 
   // Reserve dram memory
-  char* base = os::attempt_reserve_memory_at(rs_dram.size(), rs_dram.base());
+  char* base = os::attempt_reserve_memory_at(rs_dram.base(), rs_dram.size());
   if (base != rs_dram.base()) {
     if (base != NULL) {
       os::release_memory(base, rs_dram.size());

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -186,7 +186,7 @@ void ReservedSpace::initialize(size_t size, size_t alignment, bool large,
     // important.  If available space is not detected, return NULL.
 
     if (requested_address != 0) {
-      base = os::attempt_reserve_memory_at(size, requested_address, _fd_for_heap);
+      base = os::attempt_reserve_memory_at(requested_address, size, _fd_for_heap);
       if (failed_to_reserve_as_requested(base, requested_address, size, false, _fd_for_heap != -1)) {
         // OS ignored requested address. Try different address.
         base = NULL;
@@ -378,7 +378,7 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
     // important.  If available space is not detected, return NULL.
 
     if (requested_address != 0) {
-      base = os::attempt_reserve_memory_at(size, requested_address, _fd_for_heap);
+      base = os::attempt_reserve_memory_at(requested_address, size, _fd_for_heap);
     } else {
       base = os::reserve_memory_with_fd(size, alignment, _fd_for_heap);
     }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -764,7 +764,7 @@ WB_ENTRY(jlong, WB_NMTReserveMemory(JNIEnv* env, jobject o, jlong size))
 WB_END
 
 WB_ENTRY(jlong, WB_NMTAttemptReserveMemoryAt(JNIEnv* env, jobject o, jlong addr, jlong size))
-  addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((size_t)size, (char*)(uintptr_t)addr);
+  addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((char*)(uintptr_t)addr, (size_t)size);
   MemTracker::record_virtual_memory_type((address)addr, mtTest);
 
   return addr;

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1685,15 +1685,15 @@ char* os::reserve_memory_with_fd(size_t bytes, size_t alignment_hint, int file_d
   return result;
 }
 
-char* os::attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc) {
+char* os::attempt_reserve_memory_at(char* addr, size_t bytes, int file_desc) {
   char* result = NULL;
   if (file_desc != -1) {
-    result = pd_attempt_reserve_memory_at(bytes, addr, file_desc);
+    result = pd_attempt_reserve_memory_at(addr, bytes, file_desc);
     if (result != NULL) {
       MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC);
     }
   } else {
-    result = pd_attempt_reserve_memory_at(bytes, addr);
+    result = pd_attempt_reserve_memory_at(addr, bytes);
     if (result != NULL) {
       MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
     }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -117,8 +117,8 @@ class os: AllStatic {
 
   static char*  pd_reserve_memory(size_t bytes, size_t alignment_hint);
 
-  static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr);
-  static char*  pd_attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc);
+  static char*  pd_attempt_reserve_memory_at(char* addr, size_t bytes);
+  static char*  pd_attempt_reserve_memory_at(char* addr, size_t bytes, int file_desc);
 
   static bool   pd_commit_memory(char* addr, size_t bytes, bool executable);
   static bool   pd_commit_memory(char* addr, size_t size, size_t alignment_hint,
@@ -327,7 +327,7 @@ class os: AllStatic {
 
   // Attempts to reserve the virtual memory at [addr, addr + bytes).
   // Does not overwrite existing mappings.
-  static char*  attempt_reserve_memory_at(size_t bytes, char* addr, int file_desc = -1);
+  static char*  attempt_reserve_memory_at(char* addr, size_t bytes, int file_desc = -1);
 
   // Split a reserved memory region [base, base+size) into two regions [base, base+split) and
   //  [base+split, base+size).


### PR DESCRIPTION
Clean backport of https://bugs.openjdk.java.net/browse/JDK-8253639: simple changing parameter order to improve code consistency.

Testing: tier1 on Linux x86 didn't regress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8253639](https://bugs.openjdk.java.net/browse/JDK-8253639): Change os::attempt_reserve_memory_at parameter order ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/156.diff">https://git.openjdk.java.net/jdk15u-dev/pull/156.diff</a>

</details>
