### PR TITLE
8273341: Update Siphash to version 1.0

### DIFF
--- a/src/hotspot/share/classfile/altHashing.cpp
+++ b/src/hotspot/share/classfile/altHashing.cpp
@@ -26,18 +26,23 @@
  * halfsiphash code adapted from reference implementation
  * (https://github.com/veorq/SipHash/blob/master/halfsiphash.c)
  * which is distributed with the following copyright:
- *
- * SipHash reference C implementation
- *
- * Copyright (c) 2016 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
- *
- * To the extent possible under law, the author(s) have dedicated all copyright
- * and related and neighboring rights to this software to the public domain
- * worldwide. This software is distributed without any warranty.
- *
- * You should have received a copy of the CC0 Public Domain Dedication along
- * with this software. If not, see
- * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+/*
+   SipHash reference C implementation
+
+   Copyright (c) 2012-2021 Jean-Philippe Aumasson
+   <jeanphilippe.aumasson@gmail.com>
+   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along
+   with
+   this software. If not, see
+   <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 
 #include "precompiled.hpp"
@@ -134,7 +139,9 @@ static uint64_t halfsiphash_finish64(uint32_t v[4], int rounds) {
 }
 
 // HalfSipHash-2-4 (32-bit output) for Symbols
-uint32_t AltHashing::halfsiphash_32(uint64_t seed, const uint8_t* data, int len) {
+uint32_t AltHashing::halfsiphash_32(uint64_t seed, const void* in, int len) {
+
+  const unsigned char* data = (const unsigned char*)in;
   uint32_t v[4];
   uint32_t newdata;
   int off = 0;

--- a/src/hotspot/share/classfile/altHashing.hpp
+++ b/src/hotspot/share/classfile/altHashing.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ class AltHashing : AllStatic {
   static uint64_t compute_seed();
 
   // For Symbols
-  static uint32_t halfsiphash_32(uint64_t seed, const uint8_t* data, int len);
+  static uint32_t halfsiphash_32(uint64_t seed, const void* in, int len);
   // For Strings
   static uint32_t halfsiphash_32(uint64_t seed, const uint16_t* data, int len);
 };


### PR DESCRIPTION
I'd like to backport it to 15u where there is the previous version, too. The patch applies cleanly, hotspot/runtime tests run OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273341](https://bugs.openjdk.java.net/browse/JDK-8273341): Update Siphash to version 1.0


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/160.diff">https://git.openjdk.java.net/jdk15u-dev/pull/160.diff</a>

</details>
