### PR TITLE
8251260: two MD5 tests fail "RuntimeException: Unexpected count of intrinsic"

### DIFF
--- a/test/hotspot/jtreg/ProblemList-aot.txt
+++ b/test/hotspot/jtreg/ProblemList-aot.txt
@@ -78,12 +78,5 @@ serviceability/sa/TestRevPtrsForInvokeDynamic.java      8216181   generic-all
 serviceability/sa/TestType.java                         8216181   generic-all
 serviceability/sa/TestUniverse.java                     8216181   generic-all
 
-compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java  8167430 generic-all
-compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java              8167430 generic-all
-compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java            8167430 generic-all
-compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java            8167430 generic-all
-compiler/intrinsics/sha/sanity/TestSHA1MultiBlockIntrinsics.java    8167430 generic-all
-compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java  8167430 generic-all
-
 vmTestbase/vm/mlvm/indy/stress/java/relinkMutableCallSiteFreq/Test.java   8226689 generic-all
 vmTestbase/vm/mlvm/indy/stress/java/relinkVolatileCallSiteFreq/Test.java  8226689 generic-all

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5Intrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that MD5 intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5MultiBlockIntrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that MD5 multi block intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that SHA-1 intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1MultiBlockIntrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that SHA-1 multi block intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that SHA-256 intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that SHA-256 multi block intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that SHA-512 intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
@@ -25,6 +25,9 @@
  * @test
  * @bug 8035968
  * @summary Verify that SHA-512 multi block intrinsic is actually used.
+ * @comment the test verifies compilation of java.base methods, so it can't be run w/ AOT'ed java.base
+ * @requires !vm.aot.enabled
+ *
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
I'd like to backport this as a necessary follow-up to [JDK-8280978](https://bugs.openjdk.java.net/browse/JDK-8280978), which latter is the 15u backport of [JDK-8250902](https://bugs.openjdk.java.net/browse/JDK-8250902).

Applies cleanly, test-only fix that disables MD5/SHA tests for AOT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251260](https://bugs.openjdk.java.net/browse/JDK-8251260): two MD5 tests fail "RuntimeException: Unexpected count of intrinsic"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/166.diff">https://git.openjdk.java.net/jdk15u-dev/pull/166.diff</a>

</details>
