### PR TITLE
8280373: Update Xalan serializer / SystemIDResolver to align with JDK-8270492

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java
@@ -1,6 +1,5 @@
 /*
- * reserved comment block
- * DO NOT REMOVE OR ALTER!
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -42,6 +41,8 @@ import com.sun.org.apache.xml.internal.serializer.utils.URI.MalformedURIExceptio
  * used in com.sun.org.apache.xml.internal.serializer.
  *
  * @xsl.usage internal
+ *
+ * @LastModified: Jan 2022
  */
 public final class SystemIDResolver
 {
@@ -282,7 +283,7 @@ public final class SystemIDResolver
   public static String getAbsoluteURI(String urlString, String base)
           throws TransformerException
   {
-    if (base == null)
+    if (base == null || base.length() == 0)
       return getAbsoluteURI(urlString);
 
     String absoluteBase = getAbsoluteURI(base);


### PR DESCRIPTION
I'd like to backport JDK-8280373 to jdk15u in order to align after JDK-8270492 the copy 
`src/java.xml/share/classes/com/sun/org/apache/xml/internal/serializer/utils/SystemIDResolver.java`
to its origin
`src/java.xml/share/classes/com/sun/org/apache/xml/internal/utils/SystemIDResolver.java`
All regular tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280373](https://bugs.openjdk.java.net/browse/JDK-8280373): Update Xalan serializer / SystemIDResolver to align with JDK-8270492


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/170.diff">https://git.openjdk.java.net/jdk15u-dev/pull/170.diff</a>

</details>
