### PR TITLE
8281374: Add MD5.implCompress0 to Graal toBeInvestigated list after 8280978

### DIFF
--- a/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/src/jdk.internal.vm.compiler/share/classes/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -418,7 +418,7 @@ public class CheckGraalIntrinsics extends GraalTest {
                             "java/math/BigInteger.shiftRightImplWorker([I[IIII)V");
         }
 
-        if (isJDK16OrHigher()) {
+        if (isJDK15OrHigher()) {
             add(toBeInvestigated,
                             "sun/security/provider/MD5.implCompress0([BI)V");
         }
@@ -595,10 +595,6 @@ public class CheckGraalIntrinsics extends GraalTest {
 
     private static boolean isJDK15OrHigher() {
         return JavaVersionUtil.JAVA_SPEC >= 15;
-    }
-
-    private static boolean isJDK16OrHigher() {
-        return JavaVersionUtil.JAVA_SPEC >= 16;
     }
 
     public interface Refiner {


### PR DESCRIPTION
Patch to fix [JDK-8280978](https://bugs.openjdk.java.net/browse/JDK-8280978), the 15u backport of [JDK-8250902](https://bugs.openjdk.java.net/browse/JDK-8250902). Add MD5.implCompress0 to Graal toBeInvestigated list for JDK 15 and above rather than JDK 16 and above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281374](https://bugs.openjdk.java.net/browse/JDK-8281374): Add MD5.implCompress0 to Graal toBeInvestigated list after 8280978


### Reviewers
 * [Volker Simonis](https://openjdk.java.net/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/171/head:pull/171` \
`$ git checkout pull/171`

Update a local copy of the PR: \
`$ git checkout pull/171` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 171`

View PR using the GUI difftool: \
`$ git pr show -t 171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/171.diff">https://git.openjdk.java.net/jdk15u-dev/pull/171.diff</a>

</details>
