### PR TITLE
8278309: [windows] use of uninitialized OSThread::_state

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -597,6 +597,9 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     return false;
   }
 
+  // Initial state is ALLOCATED but not INITIALIZED
+  osthread->set_state(ALLOCATED);
+
   // Initialize the JDK library's interrupt event.
   // This should really be done when OSThread is constructed,
   // but there is no way for a constructor to report failure to
@@ -692,7 +695,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
   osthread->set_thread_handle(thread_handle);
   osthread->set_thread_id(thread_id);
 
-  // Initial thread state is INITIALIZED, not SUSPENDED
+  // Thread state now is INITIALIZED, not SUSPENDED
   osthread->set_state(INITIALIZED);
 
   // The thread is returned suspended (in state INITIALIZED), and is started higher up in the call chain


### PR DESCRIPTION
clean backport of a simple useful fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278309](https://bugs.openjdk.java.net/browse/JDK-8278309): [windows] use of uninitialized OSThread::_state


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/173.diff">https://git.openjdk.java.net/jdk15u-dev/pull/173.diff</a>

</details>
