### PR TITLE
8261534: Test sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java fails on platforms where no nsslib artifacts are defined

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java
+++ b/test/jdk/sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java
@@ -71,6 +71,7 @@ public class IllegalPackageAccess extends PKCS11Test {
 
     @Override
     public void main(Provider p) throws Exception {
+        Policy.setPolicy(null);
         Policy.setPolicy(new MyPolicy());
         System.setSecurityManager(new SecurityManager());
 


### PR DESCRIPTION
[JDK-8259319](https://bugs.openjdk.java.net/browse/JDK-8259319) was backported to 15u. As we see the test failing, we need to backport this testfix to 15u as well. Patch applies cleanly. No risk, testfix only.
Tested:
- `make run-test TEST=sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java`: Passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261534](https://bugs.openjdk.java.net/browse/JDK-8261534): Test sun/security/pkcs11/KeyAgreement/IllegalPackageAccess.java fails on platforms where no nsslib artifacts are defined


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/182/head:pull/182` \
`$ git checkout pull/182`

Update a local copy of the PR: \
`$ git checkout pull/182` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 182`

View PR using the GUI difftool: \
`$ git pr show -t 182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/182.diff">https://git.openjdk.java.net/jdk15u-dev/pull/182.diff</a>

</details>
