### PR TITLE
8282761: XPathFactoryImpl remove setProperty and getProperty methods

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathFactoryImpl.java
@@ -305,36 +305,4 @@ public  class XPathFactoryImpl extends XPathFactory {
 
                 xPathVariableResolver = resolver;
         }
-
-    public void setProperty(String name, String value) {
-        // property name cannot be null
-        if (name == null) {
-            String fmsg = XSLMessages.createXPATHMessage(
-                    XPATHErrorResources.ER_PROPERTY_NAME_NULL,
-                    new Object[] {CLASS_NAME,  value} );
-            throw new NullPointerException(fmsg);
-         }
-
-        // property name not recognized
-        String fmsg = XSLMessages.createXPATHMessage(
-                XPATHErrorResources.ER_PROPERTY_UNKNOWN,
-                new Object[] {name, CLASS_NAME, value} );
-        throw new IllegalArgumentException(fmsg);
-    }
-
-    public String getProperty(String name) {
-        // property name cannot be null
-        if (name == null) {
-            String fmsg = XSLMessages.createXPATHMessage(
-                    XPATHErrorResources.ER_GETTING_NULL_PROPERTY,
-                    new Object[] {CLASS_NAME} );
-            throw new NullPointerException(fmsg);
-        }
-
-        // unknown property
-        String fmsg = XSLMessages.createXPATHMessage(
-                XPATHErrorResources.ER_GETTING_UNKNOWN_PROPERTY,
-                new Object[] {name, CLASS_NAME} );
-        throw new IllegalArgumentException(fmsg);
-    }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/res/XPATHErrorResources.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/res/XPATHErrorResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -31,7 +31,7 @@ import java.util.ListResourceBundle;
   * Also you need to  update the count of messages(MAX_CODE)or
  * the count of warnings(MAX_WARNING) [ Information purpose only]
  * @xsl.usage advanced
- * @LastModified: Nov 2021
+ * @LastModified: May 2019
  */
 public class XPATHErrorResources extends ListResourceBundle
 {
@@ -322,10 +322,6 @@ public static final String ER_IGNORABLE_WHITESPACE_NOT_HANDLED =
   public static final String ER_SECUREPROCESSING_FEATURE = "ER_SECUREPROCESSING_FEATURE";
   public static final String ER_NULL_XPATH_FUNCTION_RESOLVER = "ER_NULL_XPATH_FUNCTION_RESOLVER";
   public static final String ER_NULL_XPATH_VARIABLE_RESOLVER = "ER_NULL_XPATH_VARIABLE_RESOLVER";
-  public static final String ER_PROPERTY_NAME_NULL = "ER_PROPERTY_NAME_NULL";
-  public static final String ER_PROPERTY_UNKNOWN = "ER_PROPERTY_UNKNOWN";
-  public static final String ER_GETTING_NULL_PROPERTY = "ER_GETTING_NULL_PROPERTY";
-  public static final String ER_GETTING_UNKNOWN_PROPERTY = "ER_GETTING_UNKNOWN_PROPERTY";
   //END: Keys needed for exception messages of  JAXP 1.3 XPath API implementation
 
   public static final String WG_LOCALE_NAME_NOT_HANDLED =
@@ -839,26 +835,6 @@ public static final String ER_IGNORABLE_WHITESPACE_NOT_HANDLED =
 
   { ER_NULL_XPATH_VARIABLE_RESOLVER,
        "Attempting to set a null XPathVariableResolver:{0}#setXPathVariableResolver(null)"},
-
-  /** Field ER_PROPERTY_NAME_NULL                       */
-
-  { ER_PROPERTY_NAME_NULL,
-       "Trying to set a property with a null name: {0}#setProperty( null, {1})"},
-
-  /** Field ER_PROPERTY_UNKNOWN                       */
-
-  { ER_PROPERTY_UNKNOWN,
-       "Trying to set the unknown property \"{0}\":{1}#setProperty({0},{2})"},
-
-  /** Field ER_GETTING_NULL_PROPERTY                       */
-
-  { ER_GETTING_NULL_PROPERTY,
-       "Trying to get a property with a null name: {0}#getProperty(null)"},
-
-  /** Field ER_GETTING_NULL_PROPERTY                       */
-
-  { ER_GETTING_UNKNOWN_PROPERTY,
-       "Trying to get the unknown property \"{0}\":{1}#getProperty({0})"},
 
   //END:  Definitions of error keys used  in exception messages of  JAXP 1.3 XPath API implementation
 


### PR DESCRIPTION
rollback of JDK-8276141; relevant tests do pass. We have a day before the team repository closed, so targeted there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282761](https://bugs.openjdk.java.net/browse/JDK-8282761): XPathFactoryImpl remove setProperty and getProperty methods ⚠️ Issue is not open.


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/184.diff">https://git.openjdk.java.net/jdk15u-dev/pull/184.diff</a>

</details>
