### PR TITLE
8244602: Add JTREG_REPEAT_COUNT to repeat execution of a test

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -174,6 +174,8 @@ TEST FAILURE</code></pre>
 <p>Generate AOT modules before testing for the specified module, or set of modules. If multiple modules are specified, they should be separated by space (or, to help avoid quoting issues, the special value <code>%20</code>).</p>
 <h4 id="retry_count">RETRY_COUNT</h4>
 <p>Retry failed tests up to a set number of times. Defaults to 0.</p>
+<h4 id="repeat_count">REPEAT_COUNT</h4>
+<p>Repeat the tests for a set number of times. Defaults to 0.</p>
 <h3 id="gtest-keywords">Gtest keywords</h3>
 <h4 id="repeat">REPEAT</h4>
 <p>The number of times to repeat the tests (<code>--gtest_repeat</code>).</p>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -350,6 +350,10 @@ modules. If multiple modules are specified, they should be separated by space
 
 Retry failed tests up to a set number of times. Defaults to 0.
 
+#### REPEAT_COUNT
+
+Repeat the tests for a set number of times. Defaults to 0.
+
 ### Gtest keywords
 
 #### REPEAT

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -291,7 +291,7 @@ $(eval $(call SetTestOpt,FAILURE_HANDLER_TIMEOUT,JTREG))
 $(eval $(call ParseKeywordVariable, JTREG, \
     SINGLE_KEYWORDS := JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT \
         TEST_MODE ASSERT VERBOSE RETAIN MAX_MEM RUN_PROBLEM_LISTS \
-        RETRY_COUNT, \
+        RETRY_COUNT REPEAT_COUNT, \
     STRING_KEYWORDS := OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS \
         EXTRA_PROBLEM_LISTS AOT_MODULES, \
 ))
@@ -843,6 +843,15 @@ define SetupRunJtregTestBody
   JTREG_RETAIN ?= fail,error
   JTREG_RUN_PROBLEM_LISTS ?= false
   JTREG_RETRY_COUNT ?= 0
+  JTREG_REPEAT_COUNT ?= 0
+
+  ifneq ($$(JTREG_RETRY_COUNT), 0)
+    ifneq ($$(JTREG_REPEAT_COUNT), 0)
+      $$(info Error: Cannot use both JTREG_RETRY_COUNT and JTREG_REPEAT_COUNT together.)
+      $$(info Please choose one or the other.)
+      $$(error Cannot continue)
+    endif
+  endif
 
   ifneq ($$($1_JTREG_MAX_MEM), 0)
     $1_JTREG_BASIC_OPTIONS += -vmoption:-Xmx$$($1_JTREG_MAX_MEM)
@@ -962,6 +971,18 @@ define SetupRunJtregTestBody
             break; \
           fi; \
           export JTREG_STATUS="-status:error,fail"; \
+        done
+  endif
+
+  ifneq ($$(JTREG_REPEAT_COUNT), 0)
+    $1_COMMAND_LINE := \
+        for i in {1..$$(JTREG_REPEAT_COUNT)}; do \
+          $$(PRINTF) "\nRepeating Jtreg run: $$$$i out of $$(JTREG_REPEAT_COUNT)\n"; \
+          $$($1_COMMAND_LINE); \
+          if [ "`$$(CAT) $$($1_EXITCODE)`" != "0" ]; then \
+            $$(PRINTF) "\nFailures detected, no more repeats.\n"; \
+            break; \
+          fi; \
         done
   endif
 


### PR DESCRIPTION
I'd like to port this useful and apparently not risky enhancement which is already in other update releases.
Fix was easy to apply manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244602](https://bugs.openjdk.java.net/browse/JDK-8244602): Add JTREG_REPEAT_COUNT to repeat execution of a test


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/203.diff">https://git.openjdk.java.net/jdk15u-dev/pull/203.diff</a>

</details>
