### PR TITLE
8285727: [11u, 17u] Unify fix for JDK-8284920 with version from head

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Lexer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Lexer.java
@@ -360,7 +360,7 @@ class Lexer
 
         addToTokenQueue(pat.substring(i, i + 1));
         break;
-      case Token.COLON_CHAR:
+      case Token.COLON :
         if (i>0)
         {
           if (posOfNSSep == (i - 1))
@@ -615,7 +615,7 @@ class Lexer
         resetTokenMark(tokPos + 1);
       }
 
-      if (m_processor.lookahead(Token.COLON_CHAR, 1))
+      if (m_processor.lookahead(Token.COLON, 1))
       {
         tokPos += 2;
       }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Token.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/Token.java
@@ -45,9 +45,10 @@ public final class Token {
     static final char LPAREN = '(';
     static final char RPAREN = ')';
     static final char COMMA = ',';
+    static final char DOT = '.';
     static final char AT = '@';
     static final char US = '_';
-    static final char COLON_CHAR = ':';
+    static final char COLON = ':';
     static final char SQ = '\'';
     static final char DQ = '"';
     static final char DOLLAR = '$';
@@ -57,7 +58,7 @@ public final class Token {
     static final String DIV = "div";
     static final String MOD = "mod";
     static final String QUO = "quo";
-    static final String DOT = ".";
+    static final String DOT_STR = ".";
     static final String DDOT = "..";
     static final String DCOLON = "::";
     static final String ATTR = "attribute";

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/compiler/XPathParser.java
@@ -35,7 +35,7 @@ import jdk.xml.internal.XMLSecurityManager;
  * Tokenizes and parses XPath expressions. This should really be named
  * XPathParserImpl, and may be renamed in the future.
  * @xsl.usage general
- * @LastModified: Jan 2022
+ * @LastModified: Apr 2022
  */
 public class XPathParser
 {
@@ -1413,7 +1413,7 @@ public class XPathParser
 
       matchFound = true;
     }
-    else if (lookahead(Token.LPAREN, 1) || (lookahead(Token.COLON_CHAR, 1) && lookahead(Token.LPAREN, 3)))
+    else if (lookahead(Token.LPAREN, 1) || (lookahead(Token.COLON, 1) && lookahead(Token.LPAREN, 3)))
     {
       matchFound = FunctionCall();
     }
@@ -1457,7 +1457,7 @@ public class XPathParser
 
     int opPos = m_ops.getOp(OpMap.MAPINDEX_LENGTH);
 
-    if (lookahead(Token.COLON_CHAR, 1))
+    if (lookahead(Token.COLON, 1))
     {
       appendOp(4, OpCodes.OP_EXTFUNCTION);
 
@@ -1661,7 +1661,7 @@ public class XPathParser
       opPos = m_ops.getOp(OpMap.MAPINDEX_LENGTH);
     }
 
-    if (tokenIs(Token.DOT))
+    if (tokenIs(Token.DOT_STR))
     {
       nextToken();
 
@@ -1841,7 +1841,7 @@ public class XPathParser
       m_ops.setOp(m_ops.getOp(OpMap.MAPINDEX_LENGTH), OpCodes.NODENAME);
       m_ops.setOp(OpMap.MAPINDEX_LENGTH, m_ops.getOp(OpMap.MAPINDEX_LENGTH) + 1);
 
-      if (lookahead(Token.COLON_CHAR, 1))
+      if (lookahead(Token.COLON, 1))
       {
         if (tokenIs(Token.STAR))
         {
@@ -1944,7 +1944,7 @@ public class XPathParser
   protected void QName() throws TransformerException
   {
     // Namespace
-    if(lookahead(Token.COLON_CHAR, 1))
+    if(lookahead(Token.COLON, 1))
     {
       m_ops.setOp(m_ops.getOp(OpMap.MAPINDEX_LENGTH), m_queueMark - 1);
       m_ops.setOp(OpMap.MAPINDEX_LENGTH, m_ops.getOp(OpMap.MAPINDEX_LENGTH) + 1);

--- a/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/xpath/XPathExpTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package xpath;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/*
+ * @test
+ * @bug 8284920
+ * @run testng/othervm xpath.XPathExpTest
+ * @summary Tests for various XPath Expressions.
+ */
+public class XPathExpTest {
+
+    private static final String XML =
+              "<root>"
+            + "   <child id='1'>"
+            + "       <grandchild id='1'/>"
+            + "       <grandchild id='2'/>"
+            + "   </child>"
+            + "   <child id='2'>"
+            + "       <grandchild id='3'/>"
+            + "       <grandchild id='4'/>"
+            + "   </child>"
+            + "   <child id='3'>"
+            + "       <grandchild id='5'/>"
+            + "       <grandchild id='6'/>"
+            + "   </child>"
+            + " </root>";
+    private static final String PARENT_CHILD = "child(2)";
+
+    /*
+     * DataProvider for XPath expression test.
+     * Data columns:
+     *  see parameters of the test "test"
+     */
+    @DataProvider(name = "xpathExp")
+    public Object[][] getXPathExpression() throws Exception {
+
+        return new Object[][]{
+            // verifies various forms of the parent axis
+            {"/root/child[@id='2']", PARENT_CHILD},
+            {"//grandchild[@id='3']/parent::child", PARENT_CHILD},
+            {"//grandchild[@id='3']/parent::node()", PARENT_CHILD},
+            {"//grandchild[@id='3']/parent::*", PARENT_CHILD},
+            {"//grandchild[@id='3']/parent::node()/grandchild[@id='4']/parent::node()", PARENT_CHILD},
+            {"//grandchild[@id='3']/..", PARENT_CHILD},
+            {"//grandchild[@id='3']/../grandchild[@id='4']/..", PARENT_CHILD},
+            {"//grandchild[@id='3']/parent::node()/grandchild[@id='4']/..", PARENT_CHILD},
+
+            // verifies various forms of the self axis
+            {"/root/child[@id='2']/self::child", PARENT_CHILD},
+            {"/root/child[@id='2']/self::node()", PARENT_CHILD},
+            {"/root/child[@id='2']/self::*", PARENT_CHILD},
+            {"self::node()/root/child[@id='2']", PARENT_CHILD},
+            {"/root/child[@id='2']/.", PARENT_CHILD},
+            {"./root/child[@id='2']", PARENT_CHILD},
+            {".//child[@id='2']", PARENT_CHILD},
+            {"//grandchild[@id='3']/./../grandchild[@id='4']/..", PARENT_CHILD},
+            {"//grandchild[@id='3']/./parent::node()/grandchild[@id='4']/..", PARENT_CHILD},
+        };
+    }
+
+    /**
+     * Verifies XPath expressions.
+     *
+     * @param exp XPath expression
+     * @param expected expected result
+     * @throws Exception
+     */
+    @Test(dataProvider = "xpathExp")
+    void test(String exp, String expected) throws Exception {
+        Document doc = getDoc(XML);
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nl = (NodeList) xPath.evaluate(exp, doc, XPathConstants.NODESET);
+        Node child = nl.item(0);
+        Assert.assertEquals(
+                child.getNodeName() + "(" + child.getAttributes().item(0).getNodeValue() + ")",
+                expected);
+    }
+
+    Document getDoc(String xml) throws Exception {
+        DocumentBuilderFactory dfactory = DocumentBuilderFactory.newInstance();
+        dfactory.setNamespaceAware(true);
+        DocumentBuilder docBuilder = dfactory.newDocumentBuilder();
+        InputStream is = new ByteArrayInputStream(xml.getBytes());
+        return docBuilder.parse(is);
+    }
+}


### PR DESCRIPTION
This is a necessary unification patch.
Version from 17u applies without any difference. Tested so far with regtests of jdk/javax/xml/jaxp, jaxp/javax/xml (together with JDK-8285726 patch).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285727](https://bugs.openjdk.java.net/browse/JDK-8285727): [11u, 17u] Unify fix for JDK-8284920 with version from head ⚠️ Issue is not open.


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk15u-dev pull/209/head:pull/209` \
`$ git checkout pull/209`

Update a local copy of the PR: \
`$ git checkout pull/209` \
`$ git pull https://git.openjdk.java.net/jdk15u-dev pull/209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 209`

View PR using the GUI difftool: \
`$ git pr show -t 209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk15u-dev/pull/209.diff">https://git.openjdk.java.net/jdk15u-dev/pull/209.diff</a>

</details>
