### PR TITLE
8172065: javax/swing/JTree/4908142/bug4908142.java The selected index should be "aad"

### DIFF
--- a/test/jdk/javax/swing/JTree/4908142/bug4908142.java
+++ b/test/jdk/javax/swing/JTree/4908142/bug4908142.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class bug4908142 {
             });
 
             robot.waitForIdle();
+            robot.delay(1000);
 
             SwingUtilities.invokeAndWait(new Runnable() {
 
@@ -70,12 +71,14 @@ public class bug4908142 {
             });
 
             robot.waitForIdle();
-
+            robot.delay(500);
 
             robot.keyPress(KeyEvent.VK_A);
             robot.keyRelease(KeyEvent.VK_A);
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_A);
             robot.keyRelease(KeyEvent.VK_A);
+            robot.waitForIdle();
             robot.keyPress(KeyEvent.VK_D);
             robot.keyRelease(KeyEvent.VK_D);
             robot.waitForIdle();
@@ -114,6 +117,7 @@ public class bug4908142 {
 
         JScrollPane sp = new JScrollPane(tree);
         fr.getContentPane().add(sp);
+        fr.setLocationRelativeTo(null);
         fr.setSize(200, 200);
         fr.setVisible(true);
     }


### PR DESCRIPTION
Hi all,
This pull request contains a backport of commit [082fdf47](https://github.com/openjdk/jdk/commit/082fdf479367612a7bd795d3becfe9830db4b2d6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Prasanta Sadhukhan on 6 Dec 2021 and was reviewed by Alexey Ivanov.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8172065](https://bugs.openjdk.org/browse/JDK-8172065): javax/swing/JTree/4908142/bug4908142.java The selected index should be "aad"


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/221.diff">https://git.openjdk.org/jdk15u-dev/pull/221.diff</a>

</details>
