### PR TITLE
8250863: Build error with GCC 10 in NetworkInterface.c and k_standard.c

### DIFF
--- a/src/java.base/share/native/libfdlibm/k_standard.c
+++ b/src/java.base/share/native/libfdlibm/k_standard.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2001, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -738,6 +738,10 @@ static double zero = 0.0;       /* used as const */
                 else if (!matherr(&exc)) {
                         errno = EDOM;
                 }
+                break;
+            default:
+                exc.retval = zero / zero;
+                errno = EINVAL;
                 break;
         }
         return exc.retval;

--- a/src/java.base/unix/native/libnet/NetworkInterface.c
+++ b/src/java.base/unix/native/libnet/NetworkInterface.c
@@ -1296,7 +1296,8 @@ static netif *enumIPv6Interfaces(JNIEnv *env, int sock, netif *ifs) {
 static int getIndex(int sock, const char *name) {
     struct ifreq if2;
     memset((char *)&if2, 0, sizeof(if2));
-    strncpy(if2.ifr_name, name, sizeof(if2.ifr_name) - 1);
+    strncpy(if2.ifr_name, name, sizeof(if2.ifr_name));
+    if2.ifr_name[sizeof(if2.ifr_name) - 1] = 0;
 
     if (ioctl(sock, SIOCGIFINDEX, (char *)&if2) < 0) {
         return -1;
@@ -1359,7 +1360,8 @@ static int getMTU(JNIEnv *env, int sock, const char *ifname) {
 static int getFlags(int sock, const char *ifname, int *flags) {
     struct ifreq if2;
     memset((char *)&if2, 0, sizeof(if2));
-    strncpy(if2.ifr_name, ifname, sizeof(if2.ifr_name) - 1);
+    strncpy(if2.ifr_name, ifname, sizeof(if2.ifr_name));
+    if2.ifr_name[sizeof(if2.ifr_name) - 1] = 0;
 
     if (ioctl(sock, SIOCGIFFLAGS, (char *)&if2) < 0) {
         return -1;


### PR DESCRIPTION
Need to backport this change prepared by  Yasumasa Suenaga  to fix the build with gcc 10.3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8250863](https://bugs.openjdk.org/browse/JDK-8250863): Build error with GCC 10 in NetworkInterface.c and k_standard.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/223.diff">https://git.openjdk.org/jdk15u-dev/pull/223.diff</a>

</details>
