### PR TITLE
8259707: LDAP channel binding does not work with StartTLS extension

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/ext/StartTlsResponseImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -351,6 +351,7 @@ final public class StartTlsResponseImpl extends StartTlsResponse {
                 System.out.println(
                         "StartTLS: Calling sslSocket.startHandshake");
             }
+            ldapConnection.setHandshakeCompletedListener(sslSocket);
             sslSocket.startHandshake();
             if (debug) {
                 System.out.println(


### PR DESCRIPTION
A necessary follow-up to JDK-8245527. Clean backport. All relevant tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8259707](https://bugs.openjdk.org/browse/JDK-8259707): LDAP channel binding does not work with StartTLS extension


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/229.diff">https://git.openjdk.org/jdk15u-dev/pull/229.diff</a>

</details>
