### PR TITLE
8272806: [macOS] "Apple AWT Internal Exception" when input method is changed

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CInputMethod.m
@@ -115,9 +115,7 @@ static void initializeInputMethodController() {
     AWT_ASSERT_APPKIT_THREAD;
 
     if (!view) return;
-    if (!inputMethod) return;
-
-    [view setInputMethod:inputMethod]; // inputMethod is a GlobalRef
+    [view setInputMethod:inputMethod]; // inputMethod is a GlobalRef or null to disable.
 }
 
 + (void) _nativeEndComposition:(AWTView *)view {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/LWCToolkit.m
@@ -259,6 +259,7 @@ BOOL isSWTInWebStart(JNIEnv* env) {
 
 static void AWT_NSUncaughtExceptionHandler(NSException *exception) {
     NSLog(@"Apple AWT Internal Exception: %@", [exception description]);
+    NSLog(@"trace: %@", [exception callStackSymbols]);
 }
 
 @interface AWTStarter : NSObject


### PR DESCRIPTION
should be backported to accompany [JDK-8259869](https://bugs.openjdk.org/browse/JDK-8259869) in these releases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272806](https://bugs.openjdk.org/browse/JDK-8272806): [macOS] "Apple AWT Internal Exception" when input method is changed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/245/head:pull/245` \
`$ git checkout pull/245`

Update a local copy of the PR: \
`$ git checkout pull/245` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 245`

View PR using the GUI difftool: \
`$ git pr show -t 245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/245.diff">https://git.openjdk.org/jdk15u-dev/pull/245.diff</a>

</details>
