### PR TITLE
8268894: forged ASTs can provoke an AIOOBE at com.sun.tools.javac.jvm.ClassWriter::writePosition

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeAnnotationPosition.java
@@ -295,7 +295,6 @@ public class TypeAnnotationPosition {
 
     public void updatePosOffset(int to) {
         offset = to;
-        lvarOffset = new int[]{to};
         isValidOffset = true;
     }
 

--- a/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionProcessor.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.*;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import java.util.Set;
+
+@SupportedAnnotationTypes("*")
+public class TypeAnnotationPositionProcessor extends AbstractProcessor {
+    private Trees trees;
+    private boolean processed = false;
+
+    @Override
+    public void init(ProcessingEnvironment pe) {
+        super.init(pe);
+        trees = Trees.instance(pe);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (processed) {
+            return false;
+        } else {
+            processed = true;
+        }
+        Set<? extends Element> elements = roundEnv.getRootElements();
+        TypeElement typeElement = null;
+        for (TypeElement te : ElementFilter.typesIn(elements)) {
+            if ("TypeAnnotationPositionTest".equals(te.getSimpleName().toString())) {
+                typeElement = te;
+                break;
+            }
+        }
+        for (ExecutableElement m : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
+            if ("test".equals(m.getSimpleName().toString())) {
+                MethodTree methodTree = trees.getTree(m);
+                new PositionVisitor().scan(methodTree, ((JCMethodDecl) methodTree).pos);
+            }
+        }
+        return false;
+    }
+
+    private static class PositionVisitor extends TreeScanner<Void, Integer> {
+        @Override
+        public Void scan(Tree tree, Integer p) {
+            if (tree != null) ((JCTree) tree).pos = p;
+            return super.scan(tree, p);
+        }
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+}

--- a/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/position/TypeAnnotationPositionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268894
+ * @summary Updating the type annotation position offset causes ArrayIndexOutOfBoundsException in ClassWriter
+ * @modules jdk.compiler/com.sun.tools.javac.tree
+ * @compile TypeAnnotationPositionProcessor.java
+ * @compile -processor TypeAnnotationPositionProcessor TypeAnnotationPositionTest.java
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class TypeAnnotationPositionTest {
+    TypeAnnotationPositionTest(char @MyTest [] bar) { }
+
+    @Target({ElementType.TYPE_USE})
+    @interface MyTest {
+    }
+
+    TypeAnnotationPositionTest test() {
+        char @MyTest [] val = new char[]{'1'};
+        return new TypeAnnotationPositionTest(val);
+    }
+}


### PR DESCRIPTION
the problem exists in 15, too, and should be fixed. Test and reproducer behave as expected, all non-ignored relevant tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268894](https://bugs.openjdk.org/browse/JDK-8268894): forged ASTs can provoke an AIOOBE at com.sun.tools.javac.jvm.ClassWriter::writePosition


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/247/head:pull/247` \
`$ git checkout pull/247`

Update a local copy of the PR: \
`$ git checkout pull/247` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 247`

View PR using the GUI difftool: \
`$ git pr show -t 247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/247.diff">https://git.openjdk.org/jdk15u-dev/pull/247.diff</a>

</details>
