### PR TITLE
8264792: The NumberFormat for locale sq_XK formats price incorrectly.

### DIFF
--- a/make/data/currency/CurrencyData.properties
+++ b/make/data/currency/CurrencyData.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -317,6 +317,8 @@ KI=AUD
 KP=KPW
 # KOREA (THE REPUBLIC OF)
 KR=KRW
+# KOSOVO - Not in ISO 3166/4217
+XK=EUR
 # KUWAIT
 KW=KWD
 # KYRGYZSTAN

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,8 @@
 /*
  * @test
  * @bug 4290801 4692419 4693631 5101540 5104960 6296410 6336600 6371531
- *    6488442 7036905 8008577 8039317 8074350 8074351 8150324 8167143
+ *      6488442 7036905 8008577 8039317 8074350 8074351 8150324 8167143
+ *      8264792
  * @summary Basic tests for Currency class.
  * @modules java.base/java.util:open
  *          jdk.localedata
@@ -104,7 +105,7 @@ public class CurrencyTest {
             int ctryLength = ctryCode.length();
             if (ctryLength == 0 ||
                 ctryLength == 3 || // UN M.49 code
-                ctryCode.matches("AA|Q[M-Z]|X[A-Z]|ZZ" + // user defined codes
+                ctryCode.matches("AA|Q[M-Z]|X[A-JL-Z]|ZZ" + // user defined codes, excluding "XK" (Kosovo)
                                  "AC|CP|DG|EA|EU|FX|IC|SU|TA|UK")) { // exceptional reservation codes
                 boolean gotException = false;
                 try {

--- a/test/jdk/java/util/Currency/ValidateISO4217.java
+++ b/test/jdk/java/util/Currency/ValidateISO4217.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
  * @test
  * @bug 4691089 4819436 4942982 5104960 6544471 6627549 7066203 7195759
  *      8039317 8074350 8074351 8145952 8187946 8193552 8202026 8204269
- *      8208746 8209775 8274658
+ *      8208746 8209775 8264792 8274658
  * @summary Validate ISO 4217 data for Currency class.
  * @modules java.base/java.util:open
  *          jdk.localedata
@@ -77,7 +77,7 @@ public class ValidateISO4217 {
 
         /*
          * Defined in ISO 4217 list, but don't have code and minor unit info in
-         * it. On the othe hand, both code and minor unit are defined in
+         * it. On the other hand, both code and minor unit are defined in
          * .properties file. I don't know why, though.
          */
         {"GS", "GBP", "826", "2"},      // South Georgia And The South Sandwich Islands
@@ -92,6 +92,9 @@ public class ValidateISO4217 {
         {"IM", "GBP", "826", "2"},      // Isle of Man
         {"BL", "EUR", "978", "2"},      // Saint Barthelemy
         {"MF", "EUR", "978", "2"},      // Saint Martin
+
+        /* Defined neither in ISO 4217 nor ISO 3166 list */
+        {"XK", "EUR", "978", "2"},      // Kosovo
     };
 
     /* Codes that are obsolete, do not have related country, extra currency */


### PR DESCRIPTION
backporting for parity with major releases.
Tests for currency all pass after the fix.
A list of covered fixes in ValidateISO4217.java slightly differs in 15u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264792](https://bugs.openjdk.org/browse/JDK-8264792): The NumberFormat for locale sq_XK formats price incorrectly.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/248/head:pull/248` \
`$ git checkout pull/248`

Update a local copy of the PR: \
`$ git checkout pull/248` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 248`

View PR using the GUI difftool: \
`$ git pr show -t 248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/248.diff">https://git.openjdk.org/jdk15u-dev/pull/248.diff</a>

</details>
