### PR TITLE
8287162: (zipfs) Performance regression related to support for POSIX file permissions

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -150,9 +150,9 @@ class ZipFileSystem extends FileSystem {
         this.forceEnd64 = isTrue(env, "forceZIP64End");
         this.defaultCompressionMethod = getDefaultCompressionMethod(env);
         this.supportPosix = isTrue(env, PROPERTY_POSIX);
-        this.defaultOwner = initOwner(zfpath, env);
-        this.defaultGroup = initGroup(zfpath, env);
-        this.defaultPermissions = initPermissions(env);
+        this.defaultOwner = supportPosix ? initOwner(zfpath, env) : null;
+        this.defaultGroup = supportPosix ? initGroup(zfpath, env) : null;
+        this.defaultPermissions = supportPosix ? initPermissions(env) : null;
         this.supportedFileAttributeViews = supportPosix ?
             Set.of("basic", "posix", "zip") : Set.of("basic", "zip");
         if (Files.notExists(zfpath)) {


### PR DESCRIPTION
This fix should be ported here, too, to be on par with later releases.
All test/jdk/java/util/zip test/jdk/jdk/nio/zipfs tests pass but one: jdk/java/util/zip/ZipFile/TestZipFile.java should be updated with 8207936 (there's no getMetaInfEntryNames() in ZipFile.java in 15u)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287162](https://bugs.openjdk.org/browse/JDK-8287162): (zipfs) Performance regression related to support for POSIX file permissions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/265/head:pull/265` \
`$ git checkout pull/265`

Update a local copy of the PR: \
`$ git checkout pull/265` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 265`

View PR using the GUI difftool: \
`$ git pr show -t 265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/265.diff">https://git.openjdk.org/jdk15u-dev/pull/265.diff</a>

</details>
