### PR TITLE
8293354: fastdebug build broken after JDK-8281866

### DIFF
--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1726,7 +1726,7 @@ void LinkResolver::resolve_handle_call(CallInfo& result,
     if (MethodHandles::is_signature_polymorphic_intrinsic(iid)) {
       // Check if method can be accessed by the referring class.
       // MH.linkTo* invocations are not rewritten to invokehandle.
-      assert(iid == vmIntrinsicID::_invokeBasic, "%s", vmIntrinsics::name_at(iid));
+      assert(iid == vmIntrinsics::_invokeBasic, "%s", vmIntrinsics::name_at(iid));
 
       Klass* current_klass = link_info.current_klass();
       assert(current_klass != NULL , "current_klass should not be null");


### PR DESCRIPTION
The 15u backport of JDK-8281866 uses vmIntrinsicID::_invokeBasic which is not available in 15u, and causes following error for the fastdebug configuration:

```
/ws/openjdk/jdk15u-dev/src/hotspot/share/interpreter/linkResolver.cpp:1729:21: error: use of undeclared identifier 'vmIntrinsicID'; did you mean 'vmIntrinsics'?
      assert(iid == vmIntrinsicID::_invokeBasic, "%s", vmIntrinsics::name_at(iid));
                    ^~~~~~~~~~~~~ 
                   vmIntrinsics 
```


Let's use `vmIntrinsics::_invokeBasic` instead of `vmIntrinsicID::_invokeBasic`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293354](https://bugs.openjdk.org/browse/JDK-8293354): fastdebug build broken after JDK-8281866


### Reviewers
 * [Yuri Nesterenko](https://openjdk.org/census#yan) (@yan-too - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/269/head:pull/269` \
`$ git checkout pull/269`

Update a local copy of the PR: \
`$ git checkout pull/269` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 269`

View PR using the GUI difftool: \
`$ git pr show -t 269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/269.diff">https://git.openjdk.org/jdk15u-dev/pull/269.diff</a>

</details>
