### PR TITLE
8247818: GCC 10 warning stringop-overflow with symbol code

### DIFF
--- a/src/hotspot/share/jfr/utilities/jfrDoublyLinkedList.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrDoublyLinkedList.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,6 @@ T* JfrDoublyLinkedList<T>::remove(T* const node) {
     prev->set_next(next);
   }
   --_count;
-  assert(_count >= 0, "invariant");
   assert(!in_list(node), "still in list error");
   return node;
 }

--- a/src/hotspot/share/jfr/utilities/jfrHashtable.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrHashtable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ class JfrBasicHashtable : public CHeapObj<mtTracing> {
 
   size_t hash_to_index(uintptr_t full_hash) const {
     const uintptr_t h = full_hash % _table_size;
-    assert(h >= 0 && h < _table_size, "Illegal hash value");
+    assert(h < _table_size, "Illegal hash value");
     return (size_t)h;
   }
   size_t entry_size() const { return _entry_size; }

--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -51,9 +51,7 @@ Symbol::Symbol(const u1* name, int length, int refcount) {
   _hash_and_refcount =  pack_hash_and_refcount((short)os::random(), refcount);
   _length = length;
   _body[0] = 0;  // in case length == 0
-  for (int i = 0; i < length; i++) {
-    byte_at_put(i, name[i]);
-  }
+  memcpy(_body, name, length);
 }
 
 void* Symbol::operator new(size_t sz, int len) throw() {

--- a/src/hotspot/share/oops/symbol.hpp
+++ b/src/hotspot/share/oops/symbol.hpp
@@ -125,11 +125,6 @@ class Symbol : public MetaspaceObj {
     return (int)heap_word_size(byte_size(length));
   }
 
-  void byte_at_put(int index, u1 value) {
-    assert(index >=0 && index < length(), "symbol index overflow");
-    _body[index] = value;
-  }
-
   Symbol(const u1* name, int length, int refcount);
   void* operator new(size_t size, int len) throw();
   void* operator new(size_t size, int len, Arena* arena) throw();


### PR DESCRIPTION
backporting this useful fix which is already in mainstream for long time.
There may be added an additional issue to make gcc10 happy though...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8247818](https://bugs.openjdk.org/browse/JDK-8247818): GCC 10 warning stringop-overflow with symbol code
 * [JDK-8249875](https://bugs.openjdk.org/browse/JDK-8249875): GCC 10 warnings -Wtype-limits with JFR code


### Reviewers
 * [Andrew Brygin](https://openjdk.org/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/271.diff">https://git.openjdk.org/jdk15u-dev/pull/271.diff</a>

</details>
