### PR TITLE
8257467: [TESTBUG] -Wdeprecated-declarations is reported at sigset() in exesigtest.c

### DIFF
--- a/test/hotspot/jtreg/runtime/signal/exesigtest.c
+++ b/test/hotspot/jtreg/runtime/signal/exesigtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,7 +242,14 @@ void setSignalHandler()
     } // end - dealing with sigaction
     else if (!strcmp(mode, "sigset"))
     {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         sigset(signal_num, handler);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
     } // end dealing with sigset
     printf("%s: signal handler using function '%s' has been set\n", signal_name, mode);
 }


### PR DESCRIPTION
clean backport; gcc 10 with libc 2.34 builds test-image OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257467](https://bugs.openjdk.org/browse/JDK-8257467): [TESTBUG] -Wdeprecated-declarations is reported at sigset() in exesigtest.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/275/head:pull/275` \
`$ git checkout pull/275`

Update a local copy of the PR: \
`$ git checkout pull/275` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 275`

View PR using the GUI difftool: \
`$ git pr show -t 275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/275.diff">https://git.openjdk.org/jdk15u-dev/pull/275.diff</a>

</details>
