### PR TITLE
8292579: (tz) Update Timezone Data to 2022c

### DIFF
--- a/make/data/tzdata/VERSION
+++ b/make/data/tzdata/VERSION
@@ -21,4 +21,4 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-tzdata2022a
+tzdata2022c

--- a/make/data/tzdata/africa
+++ b/make/data/tzdata/africa
@@ -182,6 +182,7 @@ Link Africa/Abidjan Africa/Freetown	# Sierra Leone
 Link Africa/Abidjan Africa/Lome		# Togo
 Link Africa/Abidjan Africa/Nouakchott	# Mauritania
 Link Africa/Abidjan Africa/Ouagadougou	# Burkina Faso
+Link Africa/Abidjan Atlantic/Reykjavik	# Iceland
 Link Africa/Abidjan Atlantic/St_Helena	# St Helena
 
 # Djibouti
@@ -192,7 +193,7 @@ Link Africa/Abidjan Atlantic/St_Helena	# St Helena
 # Egypt
 
 # Milne says Cairo used 2:05:08.9, the local mean time of the Abbasizeh
-# observatory; round to nearest.  Milne also says that the official time for
+# observatory.  Milne also says that the official time for
 # Egypt was mean noon at the Great Pyramid, 2:04:30.5, but apparently this
 # did not apply to Cairo, Alexandria, or Port Said.
 
@@ -377,6 +378,7 @@ Rule	Egypt	2014	only	-	Jul	31	24:00	1:00	S
 Rule	Egypt	2014	only	-	Sep	lastThu	24:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	2:05:08.9
 Zone	Africa/Cairo	2:05:09 -	LMT	1900 Oct
 			2:00	Egypt	EE%sT
 
@@ -430,7 +432,7 @@ Zone	Africa/Bissau	-1:02:20 -	LMT	1912 Jan  1  1:00u
 # At midnight on 30 June 1928 the clocks throughout Kenya was put forward
 # half an hour by the Alteration of Time Ordinance, 1928.
 # https://gazettes.africa/archive/ke/1928/ke-government-gazette-dated-1928-05-11-no-28.pdf
-# [Ordinance No. 11 of 1928, The Offical Gazette, 1928-06-26, p 813]
+# [Ordinance No. 11 of 1928, The Official Gazette, 1928-06-26, p 813]
 # https://books.google.com/books?id=2S0S6os32ZUC&pg=PA813
 #
 # The 1928 ordinance was repealed by the Alteration of Time (repeal) Ordinance,
@@ -1333,21 +1335,9 @@ Link Africa/Lagos Africa/Niamey		# Niger
 Link Africa/Lagos Africa/Porto-Novo	# Benin
 
 # Réunion
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Reunion	3:41:52 -	LMT	1911 Jun # Saint-Denis
-			4:00	-	+04
+# See Asia/Dubai.
 #
-# Scattered Islands (Îles Éparses) administered from Réunion are as follows.
-# The following information about them is taken from
-# Îles Éparses (<http://www.outre-mer.gouv.fr/domtom/ile.htm>, 1997-07-22,
-# in French; no longer available as of 1999-08-17).
-# We have no info about their time zone histories.
-#
-# Bassas da India - uninhabited
-# Europa Island - inhabited from 1905 to 1910 by two families
-# Glorioso Is - inhabited until at least 1958
-# Juan de Nova - uninhabited
-# Tromelin - inhabited until at least 1958
+# The Crozet Islands also observe Réunion time; see the 'antarctica' file.
 
 # Rwanda
 # See Africa/Maputo.
@@ -1379,9 +1369,10 @@ Zone	Indian/Reunion	3:41:52 -	LMT	1911 Jun # Saint-Denis
 # From Michael Deckers (2018-12-30):
 # https://www.legis-palop.org/download.jsp?idFile=102818
 # ... [The legal time of the country, which coincides with universal
-# coordinated time, will be restituted at 2 o'clock on day 1 of January, 2019.]
+# coordinated time, will be reinstituted at 2 o'clock on day 1 of January, 2019.]
 
 Zone	Africa/Sao_Tome	 0:26:56 -	LMT	1884
+		#STDOFF	-0:36:44.68
 			-0:36:45 -	LMT	1912 Jan  1 00:00u # Lisbon MT
 			 0:00	-	GMT	2018 Jan  1 01:00
 			 1:00	-	WAT	2019 Jan  1 02:00
@@ -1391,28 +1382,7 @@ Zone	Africa/Sao_Tome	 0:26:56 -	LMT	1884
 # See Africa/Abidjan.
 
 # Seychelles
-
-# From P Chan (2020-11-27):
-# Standard Time was adopted on 1907-01-01.
-#
-# Standard Time Ordinance (Chapter 237)
-# The Laws of Seychelles in Force on the 31st December, 1971, Vol. 6, p 571
-# https://books.google.com/books?id=efE-AQAAIAAJ&pg=PA571
-#
-# From Tim Parenti (2020-12-05):
-# A footnote on https://books.google.com/books?id=DYdDAQAAMAAJ&pg=PA1689
-# confirms that Ordinance No. 9 of 1906 "was brought into force on the 1st
-# January, 1907."
-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Mahe	3:41:48 -	LMT	1907 Jan  1 # Victoria
-			4:00	-	+04
-# From Paul Eggert (2001-05-30):
-# Aldabra, Farquhar, and Desroches, originally dependencies of the
-# Seychelles, were transferred to the British Indian Ocean Territory
-# in 1965 and returned to Seychelles control in 1976.  We don't know
-# whether this affected their time zone, so omit this for now.
-# Possibly the islands were uninhabited.
+# See Asia/Dubai.
 
 # Sierra Leone
 # See Africa/Abidjan.

--- a/make/data/tzdata/antarctica
+++ b/make/data/tzdata/antarctica
@@ -180,9 +180,7 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 # St Paul Island - near Amsterdam, uninhabited
 #	fishing stations operated variously 1819/1931
 #
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Indian/Kerguelen	0	-	-00	1950 # Port-aux-Français
-			5:00	-	+05
+# Kerguelen - see Indian/Maldives.
 #
 # year-round base in the main continent
 # Dumont d'Urville - see Pacific/Port_Moresby.
@@ -265,31 +263,7 @@ Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 #	year-round from 1960/61 to 1992
 
 # Vostok, since 1957-12-16, temporarily closed 1994-02/1994-11
-# From Craig Mundell (1994-12-15):
-# http://quest.arc.nasa.gov/antarctica/QA/computers/Directions,Time,ZIP
-# Vostok, which is one of the Russian stations, is set on the same
-# time as Moscow, Russia.
-#
-# From Lee Hotz (2001-03-08):
-# I queried the folks at Columbia who spent the summer at Vostok and this is
-# what they had to say about time there:
-# "in the US Camp (East Camp) we have been on New Zealand (McMurdo)
-# time, which is 12 hours ahead of GMT. The Russian Station Vostok was
-# 6 hours behind that (although only 2 miles away, i.e. 6 hours ahead
-# of GMT). This is a time zone I think two hours east of Moscow. The
-# natural time zone is in between the two: 8 hours ahead of GMT."
-#
-# From Paul Eggert (2001-05-04):
-# This seems to be hopelessly confusing, so I asked Lee Hotz about it
-# in person.  He said that some Antarctic locations set their local
-# time so that noon is the warmest part of the day, and that this
-# changes during the year and does not necessarily correspond to mean
-# solar noon.  So the Vostok time might have been whatever the clocks
-# happened to be during their visit.  So we still don't really know what time
-# it is at Vostok.  But we'll guess +06.
-#
-Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
-			6:00	-	+06
+# See Asia/Urumqi.
 
 # S Africa - year-round bases
 # Marion Island, -4653+03752

--- a/make/data/tzdata/asia
+++ b/make/data/tzdata/asia
@@ -278,10 +278,7 @@ Zone	Indian/Chagos	4:49:40	-	LMT	1907
 			6:00	-	+06
 
 # Brunei
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Brunei	7:39:40 -	LMT	1926 Mar # Bandar Seri Begawan
-			7:30	-	+0730	1933
-			8:00	-	+08
+# See Asia/Kuching.
 
 # Burma / Myanmar
 
@@ -299,6 +296,7 @@ Zone	Asia/Yangon	6:24:47 -	LMT	1880        # or Rangoon
 			6:30	-	+0630	1942 May
 			9:00	-	+09	1945 May  3
 			6:30	-	+0630
+Link Asia/Yangon Indian/Cocos
 
 # Cambodia
 # See Asia/Bangkok.
@@ -367,12 +365,9 @@ Rule	Shang	1919	only	-	Sep	30	24:00	0	S
 # in the city at the time for people who use different time standard to adjust
 # their clock to their preferred time.
 #
-# a. For the 1940 May 31 spring forward, the essay claim that it was
-# coordinared between the international settlement authority and the French
-# concession authority and have gathered support from Hong Kong and Xiamen,
-# that it would spring forward an hour from May 31 "midnight", and the essay
-# claim "Hong Kong government implemented the spring forward in the same time
-# on the same date as Shanghai".
+# a. For the 1940 May 31 spring forward, the essay [says] ... "Hong
+# Kong government implemented the spring forward in the same time on
+# the same date as Shanghai".
 #
 # b. For the 1940 fall back, it was said that they initially intended to do
 # so on September 30 00:59 at night, however they postponed it to October 12
@@ -568,7 +563,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=11	 2:00	1:00	D
 # Zhongyuan Time ("Central plain Time") UT +08
 # Now part of Asia/Shanghai.
 # most of China
-# Milne gives 8:05:43.2 for Xujiahui Observatory time; round to nearest.
+# Milne gives 8:05:43.2 for Xujiahui Observatory time....
 # Guo says Shanghai switched to UT +08 "from the end of the 19th century".
 #
 # Long-shu Time (probably as Long and Shu were two names of the area) UT +07
@@ -687,6 +682,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=11	 2:00	1:00	D
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Beijing time, used throughout China; represented by Shanghai.
+		#STDOFF	8:05:43.2
 Zone	Asia/Shanghai	8:05:43	-	LMT	1901
 			8:00	Shang	C%sT	1949 May 28
 			8:00	PRC	C%sT
@@ -694,11 +690,12 @@ Zone	Asia/Shanghai	8:05:43	-	LMT	1901
 # / Wulumuqi.  (Please use Asia/Shanghai if you prefer Beijing time.)
 Zone	Asia/Urumqi	5:50:20	-	LMT	1928
 			6:00	-	+06
+Link Asia/Urumqi Antarctica/Vostok
 
 
 # Hong Kong
 
-# Milne gives 7:36:41.7; round this.
+# Milne gives 7:36:41.7.
 
 # From Lee Yiu Chung (2009-10-24):
 # I found there are some mistakes for the...DST rule for Hong
@@ -882,7 +879,8 @@ Rule	HK	1973	only	-	Dec	30	3:30	1:00	S
 Rule	HK	1979	only	-	May	13	3:30	1:00	S
 Rule	HK	1979	only	-	Oct	21	3:30	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30  0:36:42
+		#STDOFF	7:36:41.7
+Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 29 17:00u
 			8:00	-	HKT	1941 Jun 15  3:00
 			8:00	1:00	HKST	1941 Oct  1  4:00
 			8:00	0:30	HKWT	1941 Dec 25
@@ -1357,7 +1355,7 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1854 Jun 28 # Kolkata
 #
 # From Paul Eggert (2014-09-06):
 # The 1876 Report of the Secretary of the [US] Navy, p 306 says that Batavia
-# civil time was 7:07:12.5; round to even for Jakarta.
+# civil time was 7:07:12.5.
 #
 # From Gwillim Law (2001-05-28), overriding Shanks & Pottenger:
 # http://www.sumatera-inc.com/go_to_invest/about_indonesia.asp#standtime
@@ -1393,10 +1391,11 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1854 Jun 28 # Kolkata
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 # Java, Sumatra
+		#STDOFF	7:07:12.5
 Zone Asia/Jakarta	7:07:12 -	LMT	1867 Aug 10
 # Shanks & Pottenger say the next transition was at 1924 Jan 1 0:13,
 # but this must be a typo.
-			7:07:12	-	BMT	1923 Dec 31 23:47:12 # Batavia
+			7:07:12	-	BMT	1923 Dec 31 16:40u # Batavia
 			7:20	-	+0720	1932 Nov
 			7:30	-	+0730	1942 Mar 23
 			9:00	-	+09	1945 Sep 23
@@ -1427,6 +1426,111 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 			9:00	-	WIT
 
 # Iran
+
+# From Roozbeh Pournader (2022-05-30):
+# Here's an order from the Cabinet to the rest of the government to switch to
+# Tehran time, which is mentioned to be already at +03:30:
+# https://qavanin.ir/Law/TreeText/180138
+# Just in case that goes away, I also saved a copy at archive.org:
+# https://web.archive.org/web/20220530111940/https://qavanin.ir/Law/TreeText/180138
+# Here's my translation:
+#
+# "Circular on Matching the Hours of Governmental and Official Circles
+# in Provinces
+# Approved 1314/03/22 [=1935-06-13]
+# According to the ruling of the Honorable Cabinet, it is ordered that from
+# now on in all internal provinces of the country, governmental and official
+# circles set their time to match Tehran time (three hours and half before
+# Greenwich)....
+#
+# I still haven't found out when Tehran itself switched to +03:30....
+#
+# From Paul Eggert (2022-06-05):
+# Although the above says Tehran was at +03:30 before 1935-06-13, we don't
+# know when it switched to +03:30.  For now, use 1935-06-13 as the switch date.
+# Although most likely wrong, we have no better info.
+
+# From Roozbeh Pournader (2022-06-01):
+# This is from Kayhan newspaper, one of the major Iranian newspapers, from
+# March 20, 1978, page 2:
+#
+# "Pull the clocks 60 minutes forward
+# As we informed before, from the fourth day of the month Farvardin of the
+# new year [=1978-03-24], clocks will be pulled forward, and people's daily
+# work and life program will start one hour earlier than the current program.
+# On the 1st day of the month Farvardin of this year [=1977-03-21], they had
+# pulled the clocks forward by one hour, but in the month of Mehr
+# [=1977-09-23], the clocks were pulled back by 30 minutes.
+# In this way, from the 4th day of the month Farvardin, clocks will be ahead
+# of the previous years by one hour and a half.
+# According to the new program, during the night of 4th of Farvardin, when
+# the midnight, meaning 24 o'clock is announced, the hands of the clock must
+# be pulled forward by one hour and thus consider midnight 1 o'clock in the
+# forenoon."
+#
+# This implies that in September 1977, when the daylight savings time was
+# done with, Iran didn't go back to +03:30, but immediately to +04:00.
+#
+#
+# This is from the major Iranian newspaper Ettela'at, dated [1978-08-03]...,
+# page 32. It looks like they decided to get the clocks back to +4:00
+# just in time for Ramadan that year:
+#
+# "Tomorrow Night, Pull the Clocks Back by One Hour
+# At 1 o'clock in the forenoon of Saturday 14 Mordad [=1978-08-05], the
+# clocks will be pulled one hour back and instead of 1 o'clock in the
+# forenoon, Radio Iran will announce 24 o'clock.
+# This decision was made in the Cabinet of Ministers meeting of 25 Tir
+# [=1978-07-16], [...]
+# At the beginning of the year 2537 [=March 1978: Iran was using a different
+# year number for a few years then, based on the Coronation of Cyrus the
+# Great], the country's official time was pulled forward by one hour and now
+# the official time is one hour and a half ahead compared to last year,
+# because in Farvardin of last year [=March 1977], the official time was
+# pulled forward one hour and this continued until the second half of last
+# year [=September 1977] until in the second half of last year the official
+# time was pulled back half an hour and that half hour still remains."
+#
+# This matches the time of the true noon published in the newspapers, as they
+# clearly go from +05:00 to +04:00 after that date (which happened during a
+# long weekend in Iran).
+
+# From Roozbeh Pournader (2022-05-31):
+# [Movahedi S. Cultural preconceptions of time: Can we use operational time
+# to meddle in God's Time? Comp Stud Soc Hist. 1985;27(3):385-400]
+# https://www.jstor.org/stable/178704
+# Here's the quotes from the paper:
+# 1. '"Iran's official time keeper moved the clock one hour forward as from
+# March 22, 1977 (Farvardin 2, 2536) to make maximum use of daylight and save
+# in energy consumption. Thus Iran joined such other countries as Britain in
+# observing what is known as 'daylight saving.' The proposal was originally
+# put forward by the Ministry of Energy, in no way having any influence on
+# observing religious ceremonies. Moving time one hour forward in summer
+# means that at 11:00 o'clock on March 21, the official time was set as
+# midnight March 22. Then September 24 will actually begin one hour later
+# than the end of September 23 [...]." Iran's time base thus continued to be
+# Greenwich Mean Time plus three and one-half hours (plus four and one-half
+# hours in summer).'
+#
+# The article sources this from Iran Almanac and Book of Facts, 1977, Tehran:
+# Echo of Iran, which is on Google Books at
+# https://www.google.com/books/edition/Iran_Almanac_and_Book_of_Facts/9ybVAAAAMAAJ.
+# (I confirmed it by searching for snippets.)
+#
+# 2. "After the fall of the shah, the revolutionary government returned to
+# daylight-saving time (DST) on 26 May 1979."
+#
+# This seems to have been announced just one day in advance, on 25 May 1979.
+#
+# The change in 1977 clearly seems to be the first daylight savings effort in
+# Iran. But the article doesn't mention what happened in 1978 (which was
+# still during the shah's government), or how things continued in 1979
+# onwards (which was during the Islamic Republic).
+
+# From Francis Santoni (2022-06-01):
+# for Iran and 1977 the effective change is only 20 October
+# (UIT No. 143 17.XI.1977) and not 23 September (UIT No. 141 13.IX.1977).
+# UIT is the Operational Bulletin of International Telecommunication Union.
 
 # From Roozbeh Pournader (2003-03-15):
 # This is an English translation of what I just found (originally in Persian).
@@ -1462,65 +1566,12 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 # leap year calculation involved.  There has never been any serious
 # plan to change that law....
 #
-# From Paul Eggert (2018-11-30):
-# Go with Shanks & Pottenger before Sept. 1991, and with Pournader thereafter.
-# I used the following code in GNU Emacs 26.1 to generate the "Rule Iran"
-# lines from 2008 through 2087.  Emacs 26.1 uses Ed Reingold's
-# cal-persia implementation of Birashk's approximation, which in the
-# 2008-2087 range disagrees with the astronomical Persian calendar
-# for Persian years 1404 (Gregorian 2025) and 1437 (Gregorian 2058), so
-# the following code special-cases those years.  See Table 15.1, page 264, of:
-# Edward M. Reingold and Nachum Dershowitz, Calendrical Calculations:
-# The Ultimate Edition, Cambridge University Press (2018).
-# https://www.cambridge.org/fr/academic/subjects/computer-science/computing-general-interest/calendrical-calculations-ultimate-edition-4th-edition
-# Page 258, footnote 2, of this book says there is some dispute over what will
-# happen in 2091 (and some other years after that), so this code
-# stops in 2087, as 2088 and 2089 agree with the "max" rule below.
-# (cl-loop
-#  initially (require 'cal-persia)
-#  with first-persian-year = 1387
-#  with last-persian-year = 1466
-#  ;; Exceptional years in the above range,
-#  ;; from Reingold & Dershowitz Table 15.1, page 264:
-#  with exceptional-persian-years = '(1404 1437)
-#  with range-start = nil
-#  for persian-year from first-persian-year to last-persian-year
-#  do
-#  (let*
-#      ((exceptional-year-offset
-#        (if (member persian-year exceptional-persian-years) 1 0))
-#       (beg-dst-absolute
-#        (+ (calendar-persian-to-absolute (list 1 1 persian-year))
-#           exceptional-year-offset))
-#       (end-dst-absolute
-#        (+ (calendar-persian-to-absolute (list 6 30 persian-year))
-#           exceptional-year-offset))
-#       (next-year-beg-dst-absolute
-#        (+ (calendar-persian-to-absolute (list 1 1 (1+ persian-year)))
-#           (if (member (1+ persian-year) exceptional-persian-years) 1 0)))
-#       (beg-dst (calendar-gregorian-from-absolute beg-dst-absolute))
-#       (end-dst (calendar-gregorian-from-absolute end-dst-absolute))
-#       (next-year-beg-dst (calendar-gregorian-from-absolute
-#                           next-year-beg-dst-absolute))
-#       (year (calendar-extract-year beg-dst))
-#       (range-end (if range-start year "only")))
-#    (setq range-start (or range-start year))
-#    (when (or (/= (calendar-extract-day beg-dst)
-#                  (calendar-extract-day next-year-beg-dst))
-#              (= persian-year last-persian-year))
-#      (insert
-#       (format
-#        "Rule\tIran\t%d\t%s\t-\t%s\t%2d\t24:00\t1:00\t-\n"
-#        range-start range-end
-#        (calendar-month-name (calendar-extract-month beg-dst) t)
-#        (calendar-extract-day beg-dst)))
-#      (insert
-#       (format
-#        "Rule\tIran\t%d\t%s\t-\t%s\t%2d\t24:00\t0\t-\n"
-#        range-start range-end
-#        (calendar-month-name (calendar-extract-month end-dst) t)
-#        (calendar-extract-day end-dst)))
-#      (setq range-start nil))))
+# From Paul Eggert (2022-06-30):
+# Go with Pournader for 1935 through spring 1979, and for timestamps
+# after August 1991; go with with Shanks & Pottenger for other timestamps.
+# Go with Santoni's citation of the UIT for fall 1977, as 20 October 1977
+# is 28 Mehr 1356, consistent with the "Mehr" in Pournader's source.
+# Assume that the UIT's "1930" is UTC, i.e., 24:00 local time.
 #
 # From Oscar van Vlijmen (2005-03-30), writing about future
 # discrepancies between cal-persia and the Iranian calendar:
@@ -1554,10 +1605,23 @@ Zone Asia/Jayapura	9:22:48 -	LMT	1932 Nov
 # be changed back to its previous state on the 24 hours of the
 # thirtieth day of Shahrivar.
 #
+# From Ali Mirjamali (2022-05-10):
+# Official IR News Agency announcement: irna.ir/xjJ3TT
+# ...
+# Highlights: DST will be cancelled for the next Iranian year 1402
+# (i.e 2023-March-21) and forthcoming years.
+#
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Iran	1978	1980	-	Mar	20	24:00	1:00	-
-Rule	Iran	1978	only	-	Oct	20	24:00	0	-
+# Work around a bug in zic 2022a and earlier.
+Rule	Iran	1910	only	-	Jan	 1	00:00	0	-
+#
+Rule	Iran	1977	only	-	Mar	21	23:00	1:00	-
+Rule	Iran	1977	only	-	Oct	20	24:00	0	-
+Rule	Iran	1978	only	-	Mar	24	24:00	1:00	-
+Rule	Iran	1978	only	-	Aug	 5	01:00	0	-
+Rule	Iran	1979	only	-	May	26	24:00	1:00	-
 Rule	Iran	1979	only	-	Sep	18	24:00	0	-
+Rule	Iran	1980	only	-	Mar	20	24:00	1:00	-
 Rule	Iran	1980	only	-	Sep	22	24:00	0	-
 Rule	Iran	1991	only	-	May	 2	24:00	1:00	-
 Rule	Iran	1992	1995	-	Mar	21	24:00	1:00	-
@@ -1588,85 +1652,13 @@ Rule	Iran	2017	2019	-	Mar	21	24:00	1:00	-
 Rule	Iran	2017	2019	-	Sep	21	24:00	0	-
 Rule	Iran	2020	only	-	Mar	20	24:00	1:00	-
 Rule	Iran	2020	only	-	Sep	20	24:00	0	-
-Rule	Iran	2021	2023	-	Mar	21	24:00	1:00	-
-Rule	Iran	2021	2023	-	Sep	21	24:00	0	-
-Rule	Iran	2024	only	-	Mar	20	24:00	1:00	-
-Rule	Iran	2024	only	-	Sep	20	24:00	0	-
-Rule	Iran	2025	2027	-	Mar	21	24:00	1:00	-
-Rule	Iran	2025	2027	-	Sep	21	24:00	0	-
-Rule	Iran	2028	2029	-	Mar	20	24:00	1:00	-
-Rule	Iran	2028	2029	-	Sep	20	24:00	0	-
-Rule	Iran	2030	2031	-	Mar	21	24:00	1:00	-
-Rule	Iran	2030	2031	-	Sep	21	24:00	0	-
-Rule	Iran	2032	2033	-	Mar	20	24:00	1:00	-
-Rule	Iran	2032	2033	-	Sep	20	24:00	0	-
-Rule	Iran	2034	2035	-	Mar	21	24:00	1:00	-
-Rule	Iran	2034	2035	-	Sep	21	24:00	0	-
-Rule	Iran	2036	2037	-	Mar	20	24:00	1:00	-
-Rule	Iran	2036	2037	-	Sep	20	24:00	0	-
-Rule	Iran	2038	2039	-	Mar	21	24:00	1:00	-
-Rule	Iran	2038	2039	-	Sep	21	24:00	0	-
-Rule	Iran	2040	2041	-	Mar	20	24:00	1:00	-
-Rule	Iran	2040	2041	-	Sep	20	24:00	0	-
-Rule	Iran	2042	2043	-	Mar	21	24:00	1:00	-
-Rule	Iran	2042	2043	-	Sep	21	24:00	0	-
-Rule	Iran	2044	2045	-	Mar	20	24:00	1:00	-
-Rule	Iran	2044	2045	-	Sep	20	24:00	0	-
-Rule	Iran	2046	2047	-	Mar	21	24:00	1:00	-
-Rule	Iran	2046	2047	-	Sep	21	24:00	0	-
-Rule	Iran	2048	2049	-	Mar	20	24:00	1:00	-
-Rule	Iran	2048	2049	-	Sep	20	24:00	0	-
-Rule	Iran	2050	2051	-	Mar	21	24:00	1:00	-
-Rule	Iran	2050	2051	-	Sep	21	24:00	0	-
-Rule	Iran	2052	2053	-	Mar	20	24:00	1:00	-
-Rule	Iran	2052	2053	-	Sep	20	24:00	0	-
-Rule	Iran	2054	2055	-	Mar	21	24:00	1:00	-
-Rule	Iran	2054	2055	-	Sep	21	24:00	0	-
-Rule	Iran	2056	2057	-	Mar	20	24:00	1:00	-
-Rule	Iran	2056	2057	-	Sep	20	24:00	0	-
-Rule	Iran	2058	2059	-	Mar	21	24:00	1:00	-
-Rule	Iran	2058	2059	-	Sep	21	24:00	0	-
-Rule	Iran	2060	2062	-	Mar	20	24:00	1:00	-
-Rule	Iran	2060	2062	-	Sep	20	24:00	0	-
-Rule	Iran	2063	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2063	only	-	Sep	21	24:00	0	-
-Rule	Iran	2064	2066	-	Mar	20	24:00	1:00	-
-Rule	Iran	2064	2066	-	Sep	20	24:00	0	-
-Rule	Iran	2067	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2067	only	-	Sep	21	24:00	0	-
-Rule	Iran	2068	2070	-	Mar	20	24:00	1:00	-
-Rule	Iran	2068	2070	-	Sep	20	24:00	0	-
-Rule	Iran	2071	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2071	only	-	Sep	21	24:00	0	-
-Rule	Iran	2072	2074	-	Mar	20	24:00	1:00	-
-Rule	Iran	2072	2074	-	Sep	20	24:00	0	-
-Rule	Iran	2075	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2075	only	-	Sep	21	24:00	0	-
-Rule	Iran	2076	2078	-	Mar	20	24:00	1:00	-
-Rule	Iran	2076	2078	-	Sep	20	24:00	0	-
-Rule	Iran	2079	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2079	only	-	Sep	21	24:00	0	-
-Rule	Iran	2080	2082	-	Mar	20	24:00	1:00	-
-Rule	Iran	2080	2082	-	Sep	20	24:00	0	-
-Rule	Iran	2083	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2083	only	-	Sep	21	24:00	0	-
-Rule	Iran	2084	2086	-	Mar	20	24:00	1:00	-
-Rule	Iran	2084	2086	-	Sep	20	24:00	0	-
-Rule	Iran	2087	only	-	Mar	21	24:00	1:00	-
-Rule	Iran	2087	only	-	Sep	21	24:00	0	-
-#
-# The following rules are approximations starting in the year 2088.
-# These are the best post-2088 approximations available, given the
-# restrictions of a single rule using ordinary Gregorian dates.
-# At some point this table will need to be extended, though quite
-# possibly Iran will change the rules first.
-Rule	Iran	2088	max	-	Mar	20	24:00	1:00	-
-Rule	Iran	2088	max	-	Sep	20	24:00	0	-
+Rule	Iran	2021	2022	-	Mar	21	24:00	1:00	-
+Rule	Iran	2021	2022	-	Sep	21	24:00	0	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tehran	3:25:44	-	LMT	1916
-			3:25:44	-	TMT	1946     # Tehran Mean Time
-			3:30	-	+0330	1977 Nov
+			3:25:44	-	TMT	1935 Jun 13 # Tehran Mean Time
+			3:30	Iran	+0330/+0430 1977 Oct 20 24:00
 			4:00	Iran	+04/+05	1979
 			3:30	Iran	+0330/+0430
 
@@ -2488,9 +2480,9 @@ Zone	Asia/Amman	2:23:44 -	LMT	1931
 # the third time belt (before 1930 this means +03).
 
 # From Alexander Konzurovski (2018-12-20):
-# Qyzyolrda Region (Asia/Qyzylorda) is changing its time zone from
-# UTC+6 to UTC+5 effective December 21st, 2018. The legal document is
-# located here: http://adilet.zan.kz/rus/docs/P1800000817 (russian language).
+# (Asia/Qyzylorda) is changing its time zone from UTC+6 to UTC+5
+# effective December 21st, 2018....
+# http://adilet.zan.kz/rus/docs/P1800000817 (russian language).
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 #
@@ -2767,20 +2759,8 @@ Zone	Asia/Beirut	2:22:00 -	LMT	1880
 Rule	NBorneo	1935	1941	-	Sep	14	0:00	0:20	-
 Rule	NBorneo	1935	1941	-	Dec	14	0:00	0	-
 #
-# peninsular Malaysia
-# taken from Mok Ly Yng (2003-10-30)
-# https://web.archive.org/web/20190822231045/http://www.math.nus.edu.sg/~mathelmr/teaching/timezone.html
-# This agrees with Singapore since 1905-06-01.
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Asia/Kuala_Lumpur	6:46:46 -	LMT	1901 Jan  1
-			6:55:25	-	SMT	1905 Jun  1 # Singapore M.T.
-			7:00	-	+07	1933 Jan  1
-			7:00	0:20	+0720	1936 Jan  1
-			7:20	-	+0720	1941 Sep  1
-			7:30	-	+0730	1942 Feb 16
-			9:00	-	+09	1945 Sep 12
-			7:30	-	+0730	1982 Jan  1
-			8:00	-	+08
+# For peninsular Malaysia see Asia/Singapore.
+#
 # Sabah & Sarawak
 # From Paul Eggert (2014-08-12):
 # The data entries here are mostly from Shanks & Pottenger, but the 1942, 1945
@@ -2791,12 +2771,14 @@ Zone Asia/Kuching	7:21:20	-	LMT	1926 Mar
 			8:00 NBorneo  +08/+0820	1942 Feb 16
 			9:00	-	+09	1945 Sep 12
 			8:00	-	+08
+Link Asia/Kuching Asia/Brunei
 
 # Maldives
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Malé
 			4:54:00	-	MMT	1960 # Malé Mean Time
 			5:00	-	+05
+Link Indian/Maldives Indian/Kerguelen
 
 # Mongolia
 
@@ -3631,6 +3613,7 @@ Zone	Asia/Singapore	6:55:25 -	LMT	1901 Jan  1
 			9:00	-	+09	1945 Sep 12
 			7:30	-	+0730	1982 Jan  1
 			8:00	-	+08
+Link Asia/Singapore Asia/Kuala_Lumpur
 
 # Spratly Is
 # no information
@@ -3865,7 +3848,7 @@ Zone	Asia/Damascus	2:25:12 -	LMT	1920 # Dimashq
 Zone	Asia/Dushanbe	4:35:12 -	LMT	1924 May  2
 			5:00	-	+05	1930 Jun 21
 			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
-			5:00	1:00	+05/+06	1991 Sep  9  2:00s
+			5:00	1:00	+06	1991 Sep  9  2:00s
 			5:00	-	+05
 
 # Thailand
@@ -3875,6 +3858,7 @@ Zone	Asia/Bangkok	6:42:04	-	LMT	1880
 			7:00	-	+07
 Link Asia/Bangkok Asia/Phnom_Penh	# Cambodia
 Link Asia/Bangkok Asia/Vientiane	# Laos
+Link Asia/Bangkok Indian/Christmas
 
 # Turkmenistan
 # From Shanks & Pottenger.
@@ -3890,6 +3874,8 @@ Zone	Asia/Ashgabat	3:53:32 -	LMT	1924 May  2 # or Ashkhabad
 Zone	Asia/Dubai	3:41:12 -	LMT	1920
 			4:00	-	+04
 Link Asia/Dubai Asia/Muscat	# Oman
+Link Asia/Dubai Indian/Mahe
+Link Asia/Dubai Indian/Reunion
 
 # Uzbekistan
 # Byalokoz 1919 says Uzbekistan was 4:27:53.
@@ -3901,7 +3887,8 @@ Zone	Asia/Samarkand	4:27:53 -	LMT	1924 May  2
 			6:00	-	+06	1982 Apr  1
 			5:00 RussiaAsia	+05/+06	1992
 			5:00	-	+05
-# Milne says Tashkent was 4:37:10.8; round to nearest.
+# Milne says Tashkent was 4:37:10.8.
+		#STDOFF	4:37:10.8
 Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 			5:00	-	+05	1930 Jun 21
 			6:00 RussiaAsia	+06/+07	1991 Mar 31  2:00
@@ -3920,7 +3907,7 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # The English-language name of Vietnam's most populous city is "Ho Chi Minh
 # City"; use Ho_Chi_Minh below to avoid a name of more than 14 characters.
 
-# From Paul Eggert (2014-10-21) after a heads-up from Trần Ngọc Quân:
+# From Paul Eggert (2022-07-27) after a 2014 heads-up from Trần Ngọc Quân:
 # Trần Tiến Bình's authoritative book "Lịch Việt Nam: thế kỷ XX-XXI (1901-2100)"
 # (Nhà xuất bản Văn Hoá - Thông Tin, Hanoi, 2005), pp 49-50,
 # is quoted verbatim in:
@@ -3932,8 +3919,8 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # The 1906 transition was effective July 1 and standardized Indochina to
 # Phù Liễn Observatory, legally 104° 17' 17" east of Paris.
 # It's unclear whether this meant legal Paris Mean Time (00:09:21) or
-# the Paris Meridian (2° 20' 14.03" E); the former yields 07:06:30.1333...
-# and the latter 07:06:29.333... so either way it rounds to 07:06:30,
+# the Paris Meridian; for now guess the former and round the exact
+# 07:06:30.1333... to 07:06:30.13 as the legal spec used 66 2/3 ms precision.
 # which is used below even though the modern-day Phù Liễn Observatory
 # is closer to 07:06:31.  Abbreviate Phù Liễn Mean Time as PLMT.
 #
@@ -3960,7 +3947,8 @@ Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
 # NXB Thuận Hoá, Huế, 1995.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Asia/Ho_Chi_Minh	7:06:40 -	LMT	1906 Jul  1
+		#STDOFF	7:06:30.13
+Zone Asia/Ho_Chi_Minh	7:06:30 -	LMT	1906 Jul  1
 			7:06:30	-	PLMT	1911 May  1 # Phù Liễn MT
 			7:00	-	+07	1942 Dec 31 23:00
 			8:00	-	+08	1945 Mar 14 23:00

--- a/make/data/tzdata/australasia
+++ b/make/data/tzdata/australasia
@@ -275,16 +275,10 @@ Zone Antarctica/Macquarie 0	-	-00	1899 Nov
 			10:00	AT	AE%sT
 
 # Christmas
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Indian/Christmas	7:02:52 -	LMT	1895 Feb
-			7:00	-	+07
+# See Asia/Bangkok.
 
 # Cocos (Keeling) Is
-# These islands were ruled by the Ross family from about 1830 to 1978.
-# We don't know when standard time was introduced; for now, we guess 1900.
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Indian/Cocos	6:27:40	-	LMT	1900
-			6:30	-	+0630
+# See Asia/Yangon.
 
 
 # Fiji
@@ -501,6 +495,11 @@ Link Pacific/Guam Pacific/Saipan # N Mariana Is
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Tarawa	 11:32:04 -	LMT	1901 # Bairiki
 			 12:00	-	+12
+Link Pacific/Tarawa Pacific/Funafuti
+Link Pacific/Tarawa Pacific/Majuro
+Link Pacific/Tarawa Pacific/Wake
+Link Pacific/Tarawa Pacific/Wallis
+
 Zone Pacific/Kanton	  0	-	-00	1937 Aug 31
 			-12:00	-	-12	1979 Oct
 			-11:00	-	-11	1994 Dec 31
@@ -514,15 +513,8 @@ Zone Pacific/Kiritimati	-10:29:20 -	LMT	1901
 # See Pacific/Guam.
 
 # Marshall Is
+# See Pacific/Tarawa for most locations.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Majuro	 11:24:48 -	LMT	1901
-			 11:00	-	+11	1914 Oct
-			  9:00	-	+09	1919 Feb  1
-			 11:00	-	+11	1937
-			 10:00	-	+10	1941 Apr  1
-			  9:00	-	+09	1944 Jan 30
-			 11:00	-	+11	1969 Oct
-			 12:00	-	+12
 Zone Pacific/Kwajalein	 11:09:20 -	LMT	1901
 			 11:00	-	+11	1937
 			 10:00	-	+10	1941 Apr  1
@@ -532,22 +524,9 @@ Zone Pacific/Kwajalein	 11:09:20 -	LMT	1901
 			 12:00	-	+12
 
 # Micronesia
+# For Chuuk and Yap see Pacific/Port_Moresby.
+# For Pohnpei see Pacific/Guadalcanal.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Chuuk	-13:52:52 -	LMT	1844 Dec 31
-			 10:07:08 -	LMT	1901
-			 10:00	-	+10	1914 Oct
-			  9:00	-	+09	1919 Feb  1
-			 10:00	-	+10	1941 Apr  1
-			  9:00	-	+09	1945 Aug
-			 10:00	-	+10
-Zone Pacific/Pohnpei	-13:27:08 -	LMT	1844 Dec 31	# Kolonia
-			 10:32:52 -	LMT	1901
-			 11:00	-	+11	1914 Oct
-			  9:00	-	+09	1919 Feb  1
-			 11:00	-	+11	1937
-			 10:00	-	+10	1941 Apr  1
-			  9:00	-	+09	1945 Aug
-			 11:00	-	+11
 Zone Pacific/Kosrae	-13:08:04 -	LMT	1844 Dec 31
 			 10:51:56 -	LMT	1901
 			 11:00	-	+11	1914 Oct
@@ -617,11 +596,11 @@ Rule	Chatham	2008	max	-	Apr	Sun>=1	2:45s	0	-
 Zone Pacific/Auckland	11:39:04 -	LMT	1868 Nov  2
 			11:30	NZ	NZ%sT	1946 Jan  1
 			12:00	NZ	NZ%sT
+Link Pacific/Auckland Antarctica/McMurdo
+
 Zone Pacific/Chatham	12:13:48 -	LMT	1868 Nov  2
 			12:15	-	+1215	1946 Jan  1
 			12:45	Chatham	+1245/+1345
-
-Link Pacific/Auckland Antarctica/McMurdo
 
 # Auckland Is
 # uninhabited; Māori and Moriori, colonial settlers, pastoralists, sealers,
@@ -681,7 +660,7 @@ Zone Pacific/Rarotonga	13:20:56 -	LMT	1899 Dec 26 # Avarua
 
 
 # Niue
-# See Pacific/Raratonga comments for 1952 transition.
+# See Pacific/Rarotonga comments for 1952 transition.
 #
 # From Tim Parenti (2021-09-13):
 # Consecutive contemporaneous editions of The Air Almanac listed -11:20 for
@@ -717,6 +696,7 @@ Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 			9:48:32	-	PMMT	1895 # Port Moresby Mean Time
 			10:00	-	+10
 Link Pacific/Port_Moresby Antarctica/DumontDUrville
+Link Pacific/Port_Moresby Pacific/Chuuk
 #
 # From Paul Eggert (2014-10-13):
 # Base the Bougainville entry on the Arawa-Kieta region, which appears to have
@@ -844,6 +824,7 @@ Zone Pacific/Apia	 12:33:04 -	LMT	1892 Jul  5
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone Pacific/Guadalcanal 10:39:48 -	LMT	1912 Oct # Honiara
 			11:00	-	+11
+Link Pacific/Guadalcanal Pacific/Pohnpei
 
 # Tokelau
 #
@@ -884,9 +865,7 @@ Zone Pacific/Tongatapu	12:19:12 -	LMT	1945 Sep 10
 			13:00	Tonga	+13/+14
 
 # Tuvalu
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Pacific/Funafuti	11:56:52 -	LMT	1901
-			12:00	-	+12
+# See Pacific/Tarawa.
 
 
 # US minor outlying islands
@@ -945,9 +924,7 @@ Zone Pacific/Funafuti	11:56:52 -	LMT	1901
 # uninhabited since World War II; was probably like Pacific/Kiritimati
 
 # Wake
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Wake	11:06:28 -	LMT	1901
-			12:00	-	+12
+# See Pacific/Tarawa.
 
 
 # Vanuatu
@@ -986,9 +963,7 @@ Zone	Pacific/Efate	11:13:16 -	LMT	1912 Jan 13 # Vila
 			11:00	Vanuatu	+11/+12
 
 # Wallis and Futuna
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Pacific/Wallis	12:15:20 -	LMT	1901
-			12:00	-	+12
+# See Pacific/Tarawa.
 
 ###############################################################################
 
@@ -1306,6 +1281,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # to have the extra hour of sunshine removed from their area."  See:
 # Daylight saving coming to WA in 2019. Guardian Express. 2018-04-01.
 # https://www.communitynews.com.au/guardian-express/news/exclusive-daylight-savings-coming-wa-summer-2018/
+# [The article ends with "Today's date is April 1."]
 
 # Queensland
 
@@ -1849,16 +1825,12 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # "In Marshall Islands, Friday is followed by Sunday", NY Times. 1993-08-22.
 # https://www.nytimes.com/1993/08/22/world/in-marshall-islands-friday-is-followed-by-sunday.html
 
-# From Phake Nick (2018-10-27):
-# <https://wiki.suikawiki.org/n/南洋群島の標準時> ... pointed out that
-# currently tzdata say Pacific/Kwajalein switched from GMT+11 to GMT-12 in
-# 1969 October without explanation, however an 1993 article from NYT say it
-# synchorized its day with US mainland about 40 years ago and thus the switch
-# should occur at around 1950s instead.
-#
-# From Paul Eggert (2018-11-18):
-# The NYT (actually, AP) article is vague and possibly wrong about this.
-# The article says the earlier switch was "40 years ago when the United States
+# From Paul Eggert (2022-03-31):
+# Phake Nick (2018-10-27) noted <https://wiki.suikawiki.org/n/南洋群島の標準時>'s
+# citation of a 1993 AP article published in the New York Times saying
+# Kwajalein synchronized its day with the US mainland about 40 years earlier.
+# However the AP article is vague and possibly wrong about this.  The article
+# says the earlier switch was "about 40 years ago when the United States
 # Army established a missile test range here".  However, the Kwajalein Test
 # Center was established on 1960-10-01 and was run by the US Navy.  It was
 # transferred to the US Army on 1964-07-01.  See "Seize the High Ground"
@@ -1904,13 +1876,6 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # From Paul Eggert (2018-11-18):
 # Like the Ladrones (see Guam commentary), assume the Spanish East Indies
 # kept American time until the Philippines switched at the end of 1844.
-
-# Alan Eugene Davis writes (1996-03-16),
-# "I am certain, having lived there for the past decade, that 'Truk'
-# (now properly known as Chuuk) ... is in the time zone GMT+10."
-#
-# Shanks & Pottenger write that Truk switched from UT +10 to +11
-# on 1978-10-01; ignore this for now.
 
 # From Paul Eggert (1999-10-29):
 # The Federated States of Micronesia Visitors Board writes in
@@ -2242,32 +2207,12 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # through the third Sunday in January at 03:00, like Fiji, for now.
 
 # From David Wade (2017-10-18):
-# In August government was disolved by the King.  The current prime minister
+# In August government was dissolved by the King.  The current prime minister
 # continued in office in care taker mode.  It is easy to see that few
 # decisions will be made until elections 16th November.
 #
 # From Paul Eggert (2017-10-18):
 # For now, guess that DST is discontinued.  That's what the IATA is guessing.
-
-
-# Wake
-
-# From Vernice Anderson, Personal Secretary to Philip Jessup,
-# US Ambassador At Large (oral history interview, 1971-02-02):
-#
-# Saturday, the 14th [of October, 1950] - ...  The time was all the
-# more confusing at that point, because we had crossed the
-# International Date Line, thus getting two Sundays.  Furthermore, we
-# discovered that Wake Island had two hours of daylight saving time
-# making calculation of time in Washington difficult if not almost
-# impossible.
-#
-# https://www.trumanlibrary.org/oralhist/andrsonv.htm
-
-# From Paul Eggert (2003-03-23):
-# We have no other report of DST in Wake Island, so omit this info for now.
-
-# See also the commentary for Micronesia.
 
 
 ###############################################################################

--- a/make/data/tzdata/backward
+++ b/make/data/tzdata/backward
@@ -27,9 +27,14 @@
 # 2009-05-17 by Arthur David Olson.
 
 # This file provides links from old or merged timezone names to current ones.
-# Many names changed in late 1993.  Several of these names are
+# Many names changed in late 1993, and many merged names moved here
+# in the period from 2013 through 2022.  Several of these names are
 # also present in the file 'backzone', which has data important only
 # for pre-1970 timestamps and so is out of scope for tzdb proper.
+
+# Although this file is optional and tzdb will work if you omit it by
+# building with 'make BACKWARD=', in practice downstream users
+# typically use this file for backward compatibility.
 
 # Link	TARGET			LINK-NAME
 Link	Africa/Nairobi		Africa/Asmera
@@ -71,7 +76,7 @@ Link	Asia/Thimphu		Asia/Thimbu
 Link	Asia/Makassar		Asia/Ujung_Pandang
 Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
 Link	Atlantic/Faroe		Atlantic/Faeroe
-Link	Europe/Oslo		Atlantic/Jan_Mayen
+Link	Europe/Berlin		Atlantic/Jan_Mayen
 Link	Australia/Sydney	Australia/ACT
 Link	Australia/Sydney	Australia/Canberra
 Link	Australia/Hobart	Australia/Currie
@@ -106,6 +111,7 @@ Link	Africa/Cairo		Egypt
 Link	Europe/Dublin		Eire
 Link	Etc/UTC			Etc/UCT
 Link	Europe/London		Europe/Belfast
+Link	Europe/Kyiv		Europe/Kiev
 Link	Europe/Chisinau		Europe/Tiraspol
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
@@ -114,7 +120,7 @@ Link	Etc/GMT			GMT-0
 Link	Etc/GMT			GMT0
 Link	Etc/GMT			Greenwich
 Link	Asia/Hong_Kong		Hongkong
-Link	Atlantic/Reykjavik	Iceland
+Link	Africa/Abidjan		Iceland
 Link	Asia/Tehran		Iran
 Link	Asia/Jerusalem		Israel
 Link	America/Jamaica		Jamaica
@@ -130,10 +136,10 @@ Link	America/Denver		Navajo
 Link	Asia/Shanghai		PRC
 Link	Pacific/Kanton		Pacific/Enderbury
 Link	Pacific/Honolulu	Pacific/Johnston
-Link	Pacific/Pohnpei		Pacific/Ponape
+Link	Pacific/Guadalcanal	Pacific/Ponape
 Link	Pacific/Pago_Pago	Pacific/Samoa
-Link	Pacific/Chuuk		Pacific/Truk
-Link	Pacific/Chuuk		Pacific/Yap
+Link	Pacific/Port_Moresby	Pacific/Truk
+Link	Pacific/Port_Moresby	Pacific/Yap
 Link	Europe/Warsaw		Poland
 Link	Europe/Lisbon		Portugal
 Link	Asia/Taipei		ROC

--- a/make/data/tzdata/etcetera
+++ b/make/data/tzdata/etcetera
@@ -40,12 +40,16 @@
 # behind GMT but uses the completely misleading abbreviation "GMT".
 
 Zone	Etc/GMT		0	-	GMT
+
+# The following zone is used by tzcode functions like gmtime,
+# which load the "UTC" file to handle seconds properly.
 Zone	Etc/UTC		0	-	UTC
 
 # The following link uses older naming conventions,
 # but it belongs here, not in the file 'backward',
-# as functions like gmtime load the "GMT" file to handle leap seconds properly.
-# We want this to work even on installations that omit the other older names.
+# as it is needed for tzcode releases through 2022a,
+# where functions like gmtime load "GMT" instead of the "Etc/UTC".
+# We want this to work even on installations that omit 'backward'.
 Link	Etc/GMT				GMT
 
 Link	Etc/UTC				Etc/Universal

--- a/make/data/tzdata/europe
+++ b/make/data/tzdata/europe
@@ -326,8 +326,7 @@
 # UT-00:25:22 and cites the International Telegraph Bureau.  As it is
 # not clear that there was any practical significance to the change
 # from UT-00:25:22 to UT-00:25:21.1 in civil timekeeping, omit this
-# transition for now and just use the latter value, omitting its
-# fraction since our format cannot represent fractions.
+# transition for now and just use the latter value.
 
 # "Countess Markievicz ... claimed that the [1916] abolition of Dublin Mean Time
 # was among various actions undertaken by the 'English' government that
@@ -523,7 +522,7 @@ Rule	GB-Eire 1990	1995	-	Oct	Sun>=22	1:00u	0	GMT
 # Use Europe/London for Jersey, Guernsey, and the Isle of Man.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/London	-0:01:15 -	LMT	1847 Dec  1  0:00s
+Zone	Europe/London	-0:01:15 -	LMT	1847 Dec  1
 			 0:00	GB-Eire	%s	1968 Oct 27
 			 1:00	-	BST	1971 Oct 31  2:00u
 			 0:00	GB-Eire	%s	1996
@@ -561,7 +560,8 @@ Rule	Eire	1990	1995	-	Oct	Sun>=22	 1:00u	-1:00	-
 Rule	Eire	1996	max	-	Oct	lastSun	 1:00u	-1:00	-
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Dublin	-0:25:00 -	LMT	1880 Aug  2
+		#STDOFF	-0:25:21.1
+Zone	Europe/Dublin	-0:25:21 -	LMT	1880 Aug  2
 			-0:25:21 -	DMT	1916 May 21  2:00s
 			-0:25:21 1:00	IST	1916 Oct  1  2:00s
 			 0:00	GB-Eire	%s	1921 Dec  6 # independence
@@ -984,6 +984,8 @@ Zone	Europe/Brussels	0:17:30 -	LMT	1880
 			1:00	C-Eur	CE%sT	1944 Sep  3
 			1:00	Belgium	CE%sT	1977
 			1:00	EU	CE%sT
+Link Europe/Brussels Europe/Amsterdam
+Link Europe/Brussels Europe/Luxembourg
 
 # Bosnia and Herzegovina
 # See Europe/Belgrade.
@@ -1046,62 +1048,12 @@ Zone	Europe/Prague	0:57:44 -	LMT	1850
 # End of rearguard section.
 			1:00	Czech	CE%sT	1979
 			1:00	EU	CE%sT
-# Use Europe/Prague also for Slovakia.
+Link Europe/Prague Europe/Bratislava
+
 
 # Denmark, Faroe Islands, and Greenland
+# For Denmark see Europe/Berlin.
 
-# From Jesper Nørgaard Welen (2005-04-26):
-# the law [introducing standard time] was in effect from 1894-01-01....
-# The page https://www.retsinformation.dk/eli/lta/1893/83
-# confirms this, and states that the law was put forth 1893-03-29.
-#
-# The EU [actually, EEC and Euratom] treaty with effect from 1973:
-# https://www.retsinformation.dk/eli/lta/1972/21100
-#
-# This provoked a new law from 1974 to make possible summer time changes
-# in subsequent decrees with the law
-# https://www.retsinformation.dk/eli/lta/1974/223
-#
-# It seems however that no decree was set forward until 1980.  I have
-# not found any decree, but in another related law, the effecting DST
-# changes are stated explicitly to be from 1980-04-06 at 02:00 to
-# 1980-09-28 at 02:00.  If this is true, this differs slightly from
-# the EU rule in that DST runs to 02:00, not 03:00.  We don't know
-# when Denmark began using the EU rule correctly, but we have only
-# confirmation of the 1980-time, so I presume it was correct in 1981:
-# The law is about the management of the extra hour, concerning
-# working hours reported and effect on obligatory-rest rules (which
-# was suspended on that night):
-# https://web.archive.org/web/20140104053304/https://www.retsinformation.dk/Forms/R0710.aspx?id=60267
-
-# From Jesper Nørgaard Welen (2005-06-11):
-# The Herning Folkeblad (1980-09-26) reported that the night between
-# Saturday and Sunday the clock is set back from three to two.
-
-# From Paul Eggert (2005-06-11):
-# Hence the "02:00" of the 1980 law refers to standard time, not
-# wall-clock time, and so the EU rules were in effect in 1980.
-
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Denmark	1916	only	-	May	14	23:00	1:00	S
-Rule	Denmark	1916	only	-	Sep	30	23:00	0	-
-Rule	Denmark	1940	only	-	May	15	 0:00	1:00	S
-Rule	Denmark	1945	only	-	Apr	 2	 2:00s	1:00	S
-Rule	Denmark	1945	only	-	Aug	15	 2:00s	0	-
-Rule	Denmark	1946	only	-	May	 1	 2:00s	1:00	S
-Rule	Denmark	1946	only	-	Sep	 1	 2:00s	0	-
-Rule	Denmark	1947	only	-	May	 4	 2:00s	1:00	S
-Rule	Denmark	1947	only	-	Aug	10	 2:00s	0	-
-Rule	Denmark	1948	only	-	May	 9	 2:00s	1:00	S
-Rule	Denmark	1948	only	-	Aug	 8	 2:00s	0	-
-#
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Copenhagen	 0:50:20 -	LMT	1890
-			 0:50:20 -	CMT	1894 Jan  1 # Copenhagen MT
-			 1:00	Denmark	CE%sT	1942 Nov  2  2:00s
-			 1:00	C-Eur	CE%sT	1945 Apr  2  2:00
-			 1:00	Denmark	CE%sT	1980
-			 1:00	EU	CE%sT
 Zone Atlantic/Faroe	-0:27:04 -	LMT	1908 Jan 11 # Tórshavn
 			 0:00	-	WET	1981
 			 0:00	EU	WE%sT
@@ -1321,10 +1273,10 @@ Rule	Finland	1942	only	-	Oct	4	1:00	0	-
 Rule	Finland	1981	1982	-	Mar	lastSun	2:00	1:00	S
 Rule	Finland	1981	1982	-	Sep	lastSun	3:00	0	-
 
-# Milne says Helsinki (Helsingfors) time was 1:39:49.2 (official document);
-# round to nearest.
+# Milne says Helsinki (Helsingfors) time was 1:39:49.2 (official document).
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	1:39:49.2
 Zone	Europe/Helsinki	1:39:49 -	LMT	1878 May 31
 			1:39:49	-	HMT	1921 May    # Helsinki Mean Time
 			2:00	Finland	EE%sT	1983
@@ -1471,6 +1423,7 @@ Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 16
 			0:00	France	WE%sT	1945 Sep 16  3:00
 			1:00	France	CE%sT	1977
 			1:00	EU	CE%sT
+Link Europe/Paris Europe/Monaco
 
 # Germany
 
@@ -1514,21 +1467,11 @@ Zone	Europe/Berlin	0:53:28 -	LMT	1893 Apr
 			1:00 SovietZone	CE%sT	1946
 			1:00	Germany	CE%sT	1980
 			1:00	EU	CE%sT
+Link Europe/Berlin Arctic/Longyearbyen
+Link Europe/Berlin Europe/Copenhagen
+Link Europe/Berlin Europe/Oslo
+Link Europe/Berlin Europe/Stockholm
 
-# From Tobias Conradi (2011-09-12):
-# Büsingen <http://www.buesingen.de>, surrounded by the Swiss canton
-# Schaffhausen, did not start observing DST in 1980 as the rest of DE
-# (West Germany at that time) and DD (East Germany at that time) did.
-# DD merged into DE, the area is currently covered by code DE in ISO 3166-1,
-# which in turn is covered by the zone Europe/Berlin.
-#
-# Source for the time in Büsingen 1980:
-# http://www.srf.ch/player/video?id=c012c029-03b7-4c2b-9164-aa5902cd58d3
-
-# From Arthur David Olson (2012-03-03):
-# Büsingen and Zurich have shared clocks since 1970.
-
-Link	Europe/Zurich	Europe/Busingen
 
 # Georgia
 # Please see the "asia" file for Asia/Tbilisi.
@@ -1537,7 +1480,7 @@ Link	Europe/Zurich	Europe/Busingen
 
 # Gibraltar
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Gibraltar	-0:21:24 -	LMT	1880 Aug  2  0:00s
+Zone Europe/Gibraltar	-0:21:24 -	LMT	1880 Aug  2
 			0:00	GB-Eire	%s	1957 Apr 14  2:00
 			1:00	-	CET	1982
 			1:00	EU	CE%sT
@@ -1648,62 +1591,7 @@ Zone	Europe/Budapest	1:16:20 -	LMT	1890 Nov  1
 			1:00	EU	CE%sT
 
 # Iceland
-#
-# From Adam David (1993-11-06):
-# The name of the timezone in Iceland for system / mail / news purposes is GMT.
-#
-# (1993-12-05):
-# This material is paraphrased from the 1988 edition of the University of
-# Iceland Almanak.
-#
-# From January 1st, 1908 the whole of Iceland was standardised at 1 hour
-# behind GMT. Previously, local mean solar time was used in different parts
-# of Iceland, the almanak had been based on Reykjavík mean solar time which
-# was 1 hour and 28 minutes behind GMT.
-#
-# "first day of winter" referred to [below] means the first day of the 26 weeks
-# of winter, according to the old icelandic calendar that dates back to the
-# time the norsemen first settled Iceland.  The first day of winter is always
-# Saturday, but is not dependent on the Julian or Gregorian calendars.
-#
-# (1993-12-10):
-# I have a reference from the Oxford Icelandic-English dictionary for the
-# beginning of winter, which ties it to the ecclesiastical calendar (and thus
-# to the julian/gregorian calendar) over the period in question.
-#	the winter begins on the Saturday next before St. Luke's day
-#	(old style), or on St. Luke's day, if a Saturday.
-# St. Luke's day ought to be traceable from ecclesiastical sources. "old style"
-# might be a reference to the Julian calendar as opposed to Gregorian, or it
-# might mean something else (???).
-#
-# From Paul Eggert (2014-11-22):
-# The information below is taken from the 1988 Almanak; see
-# http://www.almanak.hi.is/klukkan.html
-#
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Iceland	1917	1919	-	Feb	19	23:00	1:00	-
-Rule	Iceland	1917	only	-	Oct	21	 1:00	0	-
-Rule	Iceland	1918	1919	-	Nov	16	 1:00	0	-
-Rule	Iceland	1921	only	-	Mar	19	23:00	1:00	-
-Rule	Iceland	1921	only	-	Jun	23	 1:00	0	-
-Rule	Iceland	1939	only	-	Apr	29	23:00	1:00	-
-Rule	Iceland	1939	only	-	Oct	29	 2:00	0	-
-Rule	Iceland	1940	only	-	Feb	25	 2:00	1:00	-
-Rule	Iceland	1940	1941	-	Nov	Sun>=2	 1:00s	0	-
-Rule	Iceland	1941	1942	-	Mar	Sun>=2	 1:00s	1:00	-
-# 1943-1946 - first Sunday in March until first Sunday in winter
-Rule	Iceland	1943	1946	-	Mar	Sun>=1	 1:00s	1:00	-
-Rule	Iceland	1942	1948	-	Oct	Sun>=22	 1:00s	0	-
-# 1947-1967 - first Sunday in April until first Sunday in winter
-Rule	Iceland	1947	1967	-	Apr	Sun>=1	 1:00s	1:00	-
-# 1949 and 1967 Oct transitions delayed by 1 week
-Rule	Iceland	1949	only	-	Oct	30	 1:00s	0	-
-Rule	Iceland	1950	1966	-	Oct	Sun>=22	 1:00s	0	-
-Rule	Iceland	1967	only	-	Oct	29	 1:00s	0	-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Atlantic/Reykjavik	-1:28	-	LMT	1908
-			-1:00	Iceland	-01/+00	1968 Apr  7  1:00s
-			 0:00	-	GMT
+# See Africa/Abidjan.
 
 # Italy
 #
@@ -1819,18 +1707,18 @@ Rule	Italy	1978	only	-	Oct	 1	 0:00s	0	-
 Rule	Italy	1979	only	-	Sep	30	 0:00s	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Rome	0:49:56 -	LMT	1866 Dec 12
-			0:49:56	-	RMT	1893 Oct 31 23:49:56 # Rome Mean
+			0:49:56	-	RMT	1893 Oct 31 23:00u # Rome Mean
 			1:00	Italy	CE%sT	1943 Sep 10
 			1:00	C-Eur	CE%sT	1944 Jun  4
 			1:00	Italy	CE%sT	1980
 			1:00	EU	CE%sT
+Link Europe/Rome Europe/Vatican
+Link Europe/Rome Europe/San_Marino
+
 
 # Kosovo
 # See Europe/Belgrade.
 
-
-Link	Europe/Rome	Europe/Vatican
-Link	Europe/Rome	Europe/San_Marino
 
 # Latvia
 
@@ -1915,16 +1803,7 @@ Zone	Europe/Riga	1:36:34	-	LMT	1880
 			2:00	EU	EE%sT
 
 # Liechtenstein
-
-# From Paul Eggert (2013-09-09):
-# Shanks & Pottenger say Vaduz is like Zurich.
-
-# From Alois Treindl (2019-07-04):
-# I was able to access the online archive of the Vaduz paper Vaterland ...
-# I could confirm from the paper that Liechtenstein did in fact follow
-# the same DST in 1941 and 1942 as Switzerland did.
-
-Link Europe/Zurich Europe/Vaduz
+# See Europe/Zurich.
 
 
 # Lithuania
@@ -1980,40 +1859,7 @@ Zone	Europe/Vilnius	1:41:16	-	LMT	1880
 			2:00	EU	EE%sT
 
 # Luxembourg
-# Whitman disagrees with most of these dates in minor ways;
-# go with Shanks & Pottenger.
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Lux	1916	only	-	May	14	23:00	1:00	S
-Rule	Lux	1916	only	-	Oct	 1	 1:00	0	-
-Rule	Lux	1917	only	-	Apr	28	23:00	1:00	S
-Rule	Lux	1917	only	-	Sep	17	 1:00	0	-
-Rule	Lux	1918	only	-	Apr	Mon>=15	 2:00s	1:00	S
-Rule	Lux	1918	only	-	Sep	Mon>=15	 2:00s	0	-
-Rule	Lux	1919	only	-	Mar	 1	23:00	1:00	S
-Rule	Lux	1919	only	-	Oct	 5	 3:00	0	-
-Rule	Lux	1920	only	-	Feb	14	23:00	1:00	S
-Rule	Lux	1920	only	-	Oct	24	 2:00	0	-
-Rule	Lux	1921	only	-	Mar	14	23:00	1:00	S
-Rule	Lux	1921	only	-	Oct	26	 2:00	0	-
-Rule	Lux	1922	only	-	Mar	25	23:00	1:00	S
-Rule	Lux	1922	only	-	Oct	Sun>=2	 1:00	0	-
-Rule	Lux	1923	only	-	Apr	21	23:00	1:00	S
-Rule	Lux	1923	only	-	Oct	Sun>=2	 2:00	0	-
-Rule	Lux	1924	only	-	Mar	29	23:00	1:00	S
-Rule	Lux	1924	1928	-	Oct	Sun>=2	 1:00	0	-
-Rule	Lux	1925	only	-	Apr	 5	23:00	1:00	S
-Rule	Lux	1926	only	-	Apr	17	23:00	1:00	S
-Rule	Lux	1927	only	-	Apr	 9	23:00	1:00	S
-Rule	Lux	1928	only	-	Apr	14	23:00	1:00	S
-Rule	Lux	1929	only	-	Apr	20	23:00	1:00	S
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Luxembourg	0:24:36 -	LMT	1904 Jun
-			1:00	Lux	CE%sT	1918 Nov 25
-			0:00	Lux	WE%sT	1929 Oct  6  2:00s
-			0:00	Belgium	WE%sT	1940 May 14  3:00
-			1:00	C-Eur	WE%sT	1944 Sep 18  3:00
-			1:00	Belgium	CE%sT	1977
-			1:00	EU	CE%sT
+# See Europe/Brussels.
 
 # North Macedonia
 # See Europe/Belgrade.
@@ -2032,7 +1878,7 @@ Rule	Malta	1975	1979	-	Apr	Sun>=15	2:00	1:00	S
 Rule	Malta	1975	1980	-	Sep	Sun>=15	2:00	0	-
 Rule	Malta	1980	only	-	Mar	31	2:00	1:00	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2  0:00s # Valletta
+Zone	Europe/Malta	0:58:04 -	LMT	1893 Nov  2 # Valletta
 			1:00	Italy	CE%sT	1973 Mar 31
 			1:00	Malta	CE%sT	1981
 			1:00	EU	CE%sT
@@ -2114,126 +1960,16 @@ Zone	Europe/Chisinau	1:55:20 -	LMT	1880
 			2:00	Moldova	EE%sT
 
 # Monaco
-#
-# From Michael Deckers (2020-06-12):
-# In the "Journal de Monaco" of 1892-05-24, online at
-# https://journaldemonaco.gouv.mc/var/jdm/storage/original/application/b1c67c12c5af11b41ea888fb048e4fe8.pdf
-# we read: ...
-#  [In virtue of a Sovereign Ordinance of the May 13 of the current [year],
-#   legal time in the Principality will be set to, from the date of June 1,
-#   1892 onwards, to the meridian of Paris, as in France.]
-# In the "Journal de Monaco" of 1911-03-28, online at
-# https://journaldemonaco.gouv.mc/var/jdm/storage/original/application/de74ffb7db53d4f599059fe8f0ed482a.pdf
-# we read an ordinance of 1911-03-16: ...
-#  [Legal time in the Principality will be set, from the date of promulgation
-#   of the present ordinance, to legal time in France....  Consequently, legal
-#   time will be retarded by 9 minutes and 21 seconds.]
-#
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Monaco	0:29:32 -	LMT	1892 Jun  1
-			0:09:21	-	PMT	1911 Mar 29 # Paris Mean Time
-			0:00	France	WE%sT	1945 Sep 16  3:00
-			1:00	France	CE%sT	1977
-			1:00	EU	CE%sT
+# See Europe/Paris.
 
 # Montenegro
 # See Europe/Belgrade.
 
 # Netherlands
-
-# Howse writes that the Netherlands' railways used GMT between 1892 and 1940,
-# but for other purposes the Netherlands used Amsterdam mean time.
-
-# However, Robert H. van Gent writes (2001-04-01):
-# Howse's statement is only correct up to 1909. From 1909-05-01 (00:00:00
-# Amsterdam mean time) onwards, the whole of the Netherlands (including
-# the Dutch railways) was required by law to observe Amsterdam mean time
-# (19 minutes 32.13 seconds ahead of GMT). This had already been the
-# common practice (except for the railways) for many decades but it was
-# not until 1909 when the Dutch government finally defined this by law.
-# On 1937-07-01 this was changed to 20 minutes (exactly) ahead of GMT and
-# was generally known as Dutch Time ("Nederlandse Tijd").
-#
-# (2001-04-08):
-# 1892-05-01 was the date when the Dutch railways were by law required to
-# observe GMT while the remainder of the Netherlands adhered to the common
-# practice of following Amsterdam mean time.
-#
-# (2001-04-09):
-# In 1835 the authorities of the province of North Holland requested the
-# municipal authorities of the towns and cities in the province to observe
-# Amsterdam mean time but I do not know in how many cases this request was
-# actually followed.
-#
-# From 1852 onwards the Dutch telegraph offices were by law required to
-# observe Amsterdam mean time. As the time signals from the observatory of
-# Leiden were also distributed by the telegraph system, I assume that most
-# places linked up with the telegraph (and railway) system automatically
-# adopted Amsterdam mean time.
-#
-# Although the early Dutch railway companies initially observed a variety
-# of times, most of them had adopted Amsterdam mean time by 1858 but it
-# was not until 1866 when they were all required by law to observe
-# Amsterdam mean time.
-
-# The data entries before 1945 are taken from
-# https://www.staff.science.uu.nl/~gent0113/wettijd/wettijd.htm
-
-# From Paul Eggert (2021-05-09):
-# I invented the abbreviations AMT for Amsterdam Mean Time and NST for
-# Netherlands Summer Time, used in the Netherlands from 1835 to 1937.
-
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Neth	1916	only	-	May	 1	0:00	1:00	NST	# Netherlands Summer Time
-Rule	Neth	1916	only	-	Oct	 1	0:00	0	AMT	# Amsterdam Mean Time
-Rule	Neth	1917	only	-	Apr	16	2:00s	1:00	NST
-Rule	Neth	1917	only	-	Sep	17	2:00s	0	AMT
-Rule	Neth	1918	1921	-	Apr	Mon>=1	2:00s	1:00	NST
-Rule	Neth	1918	1921	-	Sep	lastMon	2:00s	0	AMT
-Rule	Neth	1922	only	-	Mar	lastSun	2:00s	1:00	NST
-Rule	Neth	1922	1936	-	Oct	Sun>=2	2:00s	0	AMT
-Rule	Neth	1923	only	-	Jun	Fri>=1	2:00s	1:00	NST
-Rule	Neth	1924	only	-	Mar	lastSun	2:00s	1:00	NST
-Rule	Neth	1925	only	-	Jun	Fri>=1	2:00s	1:00	NST
-# From 1926 through 1939 DST began 05-15, except that it was delayed by a week
-# in years when 05-15 fell in the Pentecost weekend.
-Rule	Neth	1926	1931	-	May	15	2:00s	1:00	NST
-Rule	Neth	1932	only	-	May	22	2:00s	1:00	NST
-Rule	Neth	1933	1936	-	May	15	2:00s	1:00	NST
-Rule	Neth	1937	only	-	May	22	2:00s	1:00	NST
-Rule	Neth	1937	only	-	Jul	 1	0:00	1:00	S
-Rule	Neth	1937	1939	-	Oct	Sun>=2	2:00s	0	-
-Rule	Neth	1938	1939	-	May	15	2:00s	1:00	S
-Rule	Neth	1945	only	-	Apr	 2	2:00s	1:00	S
-Rule	Neth	1945	only	-	Sep	16	2:00s	0	-
-#
-# Amsterdam Mean Time was +00:19:32.13, but the .13 is omitted
-# below because the current format requires STDOFF to be an integer.
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Amsterdam	0:19:32 -	LMT	1835
-			0:19:32	Neth	%s	1937 Jul  1
-			0:20	Neth +0020/+0120 1940 May 16  0:00
-			1:00	C-Eur	CE%sT	1945 Apr  2  2:00
-			1:00	Neth	CE%sT	1977
-			1:00	EU	CE%sT
+# See Europe/Brussels.
 
 # Norway
-# http://met.no/met/met_lex/q_u/sommertid.html (2004-01) agrees with Shanks &
-# Pottenger.
-# Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
-Rule	Norway	1916	only	-	May	22	1:00	1:00	S
-Rule	Norway	1916	only	-	Sep	30	0:00	0	-
-Rule	Norway	1945	only	-	Apr	 2	2:00s	1:00	S
-Rule	Norway	1945	only	-	Oct	 1	2:00s	0	-
-Rule	Norway	1959	1964	-	Mar	Sun>=15	2:00s	1:00	S
-Rule	Norway	1959	1965	-	Sep	Sun>=15	2:00s	0	-
-Rule	Norway	1965	only	-	Apr	25	2:00s	1:00	S
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Oslo	0:43:00 -	LMT	1895 Jan  1
-			1:00	Norway	CE%sT	1940 Aug 10 23:00
-			1:00	C-Eur	CE%sT	1945 Apr  2  2:00
-			1:00	Norway	CE%sT	1980
-			1:00	EU	CE%sT
+# See Europe/Berlin.
 
 # Svalbard & Jan Mayen
 
@@ -2280,9 +2016,9 @@ Zone	Europe/Oslo	0:43:00 -	LMT	1895 Jan  1
 # the German armed forces at the Svalbard weather station code-named
 # Haudegen did not surrender to the Allies until September 1945.
 #
-# All these events predate our cutoff date of 1970, so use Europe/Oslo
+# All these events predate our cutoff date of 1970, so use Europe/Berlin
 # for these regions.
-Link	Europe/Oslo	Arctic/Longyearbyen
+
 
 # Poland
 
@@ -2336,7 +2072,6 @@ Zone	Europe/Warsaw	1:24:00 -	LMT	1880
 # According to a Portuguese decree (1911-05-26)
 # https://dre.pt/application/dir/pdf1sdip/1911/05/12500/23132313.pdf
 # Lisbon was at -0:36:44.68, but switched to GMT on 1912-01-01 at 00:00.
-# Round the old offset to -0:36:45.  This agrees with Willett....
 #
 # From Michael Deckers (2018-02-15):
 # article 5 [of the 1911 decree; Deckers's translation] ...:
@@ -2423,6 +2158,7 @@ Rule	Port	1981	1982	-	Mar	lastSun	 1:00s	1:00	S
 Rule	Port	1983	only	-	Mar	lastSun	 2:00s	1:00	S
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-0:36:44.68
 Zone	Europe/Lisbon	-0:36:45 -	LMT	1884
 			-0:36:45 -	LMT	1912 Jan  1  0:00u # Lisbon MT
 			 0:00	Port	WE%sT	1966 Apr  3  2:00
@@ -2431,9 +2167,13 @@ Zone	Europe/Lisbon	-0:36:45 -	LMT	1884
 			 0:00	W-Eur	WE%sT	1992 Sep 27  1:00s
 			 1:00	EU	CE%sT	1996 Mar 31  1:00u
 			 0:00	EU	WE%sT
-# This Zone can be simplified once we assume zic %z.
 Zone Atlantic/Azores	-1:42:40 -	LMT	1884        # Ponta Delgada
 			-1:54:32 -	HMT	1912 Jan  1  2:00u # Horta MT
+# Vanguard section, for zic and other parsers that support %z.
+#			-2:00	Port	%z	1966 Apr  3  2:00
+#			-1:00	Port	%z	1983 Sep 25  1:00s
+#			-1:00	W-Eur	%z	1992 Sep 27  1:00s
+# Rearguard section, for parsers lacking %z; see ziguard.awk.
 			-2:00	Port	-02/-01	1942 Apr 25 22:00s
 			-2:00	Port	+00	1942 Aug 15 22:00s
 			-2:00	Port	-02/-01	1943 Apr 17 22:00s
@@ -2445,11 +2185,14 @@ Zone Atlantic/Azores	-1:42:40 -	LMT	1884        # Ponta Delgada
 			-2:00	Port	-02/-01	1966 Apr  3  2:00
 			-1:00	Port	-01/+00	1983 Sep 25  1:00s
 			-1:00	W-Eur	-01/+00	1992 Sep 27  1:00s
+# End of rearguard section.
 			 0:00	EU	WE%sT	1993 Mar 28  1:00u
 			-1:00	EU	-01/+00
-# This Zone can be simplified once we assume zic %z.
 Zone Atlantic/Madeira	-1:07:36 -	LMT	1884        # Funchal
 			-1:07:36 -	FMT	1912 Jan  1  1:00u # Funchal MT
+# Vanguard section, for zic and other parsers that support %z.
+#			-1:00	Port	%z	1966 Apr  3  2:00
+# Rearguard section, for parsers lacking %z; see ziguard.awk.
 			-1:00	Port	-01/+00	1942 Apr 25 22:00s
 			-1:00	Port	+01	1942 Aug 15 22:00s
 			-1:00	Port	-01/+00	1943 Apr 17 22:00s
@@ -2459,6 +2202,7 @@ Zone Atlantic/Madeira	-1:07:36 -	LMT	1884        # Funchal
 			-1:00	Port	-01/+00	1945 Apr 21 22:00s
 			-1:00	Port	+01	1945 Aug 25 22:00s
 			-1:00	Port	-01/+00	1966 Apr  3  2:00
+# End of rearguard section.
 			 0:00	Port	WE%sT	1983 Sep 25  1:00s
 			 0:00	EU	WE%sT
 
@@ -2877,20 +2621,19 @@ Zone Europe/Simferopol	 2:16:24 -	LMT	1880
 			 2:00	-	EET	1992 Mar 20
 # Central Crimea used Moscow time 1994/1997.
 #
-# From Paul Eggert (2006-03-22):
-# The _Economist_ (1994-05-28, p 45) reports that central Crimea switched
-# from Kiev to Moscow time sometime after the January 1994 elections.
+# From Paul Eggert (2022-07-21):
+# The _Economist_ (1994-05-28, p 45) reported that central Crimea switched
+# from Kyiv to Moscow time sometime after the January 1994 elections.
 # Shanks (1999) says "date of change uncertain", but implies that it happened
 # sometime between the 1994 DST switches.  Shanks & Pottenger simply say
 # 1994-09-25 03:00, but that can't be right.  For now, guess it
-# changed in May.
+# changed in May.  This change evidently didn't last long; see below.
 			 2:00	C-Eur	EE%sT	1994 May
-# From IATA SSIM (1994/1997), which also says that Kerch is still like Kiev.
-			 3:00	E-Eur	MSK/MSD	1996 Mar 31  0:00s
+# From IATA SSIM (1994/1997), which also said that Kerch is still like Kyiv.
+			 3:00	C-Eur	MSK/MSD	1996 Mar 31  0:00s
 			 3:00	1:00	MSD	1996 Oct 27  3:00s
-# IATA SSIM (1997-09) says Crimea switched to EET/EEST.
+# IATA SSIM (1997-09) said Crimea switched to EET/EEST.
 # Assume it happened in March by not changing the clocks.
-			 3:00	Russia	MSK/MSD	1997
 			 3:00	-	MSK	1997 Mar lastSun  1:00u
 # From Alexander Krivenyshev (2014-03-17):
 # time change at 2:00 (2am) on March 30, 2014
@@ -3059,11 +2802,12 @@ Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  0:00u
 # Note: Effective 2005-12-01, (59) Perm Oblast and (81) Komi-Permyak
 # Autonomous Okrug merged to form (90, RU-PER) Perm Krai.
 
-# Milne says Yekaterinburg was 4:02:32.9; round to nearest.
+# Milne says Yekaterinburg was 4:02:32.9.
 # Byalokoz 1919 says its provincial time was based on Perm, at 3:45:05.
 # Assume it switched on 1916-07-03, the time of the new standard.
 # The 1919 and 1930 transitions are from Shanks.
 
+		#STDOFF	 4:02:32.9
 Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 			 3:45:05 -	PMT	1919 Jul 15  4:00
 			 4:00	-	+04	1930 Jun 21
@@ -3375,8 +3119,8 @@ Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
 # 14-28	****	Tomponsky District
 # 14-30	****	Ust-Maysky District
 
-# From Arthur David Olson (2012-05-09):
-# Tomponskij and Ust'-Majskij switched from Vladivostok time to Yakutsk time
+# From Arthur David Olson (2022-03-21):
+# Tomponsky and Ust-Maysky switched from Vladivostok time to Yakutsk time
 # in 2011.
 
 # From Paul Eggert (2012-11-25):
@@ -3501,8 +3245,8 @@ Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
 # Asia/Ust-Nera covers parts of (14, RU-SA) Sakha (Yakutia) Republic:
 # 14-22	****	Oymyakonsky District
 
-# From Arthur David Olson (2012-05-09):
-# Ojmyakonskij [and the Kuril Islands] switched from
+# From Arthur David Olson (2022-03-21):
+# Oymyakonsky and the Kuril Islands switched from
 # Magadan time to Vladivostok time in 2011.
 #
 # From Tim Parenti (2014-07-06), per Alexander Krivenyshev (2014-07-02):
@@ -3576,7 +3320,7 @@ Link Europe/Belgrade Europe/Skopje	# North Macedonia
 Link Europe/Belgrade Europe/Zagreb	# Croatia
 
 # Slovakia
-Link Europe/Prague Europe/Bratislava
+# See Europe/Prague.
 
 # Slovenia
 # See Europe/Belgrade.
@@ -3665,7 +3409,7 @@ Rule SpainAfrica 1977	only	-	Sep	28	 0:00	0	-
 Rule SpainAfrica 1978	only	-	Jun	 1	 0:00	1:00	S
 Rule SpainAfrica 1978	only	-	Aug	 4	 0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone	Europe/Madrid	-0:14:44 -	LMT	1900 Dec 31 23:45:16
+Zone	Europe/Madrid	-0:14:44 -	LMT	1901 Jan  1  0:00u
 			 0:00	Spain	WE%sT	1940 Mar 16 23:00
 			 1:00	Spain	CE%sT	1979
 			 1:00	EU	CE%sT
@@ -3687,61 +3431,7 @@ Zone	Atlantic/Canary	-1:01:36 -	LMT	1922 Mar # Las Palmas de Gran C.
 # Ignore this for now, as the Canaries are part of the EU.
 
 # Sweden
-
-# From Ivan Nilsson (2001-04-13), superseding Shanks & Pottenger:
-#
-# The law "Svensk författningssamling 1878, no 14" about standard time in 1879:
-# From the beginning of 1879 (that is 01-01 00:00) the time for all
-# places in the country is "the mean solar time for the meridian at
-# three degrees, or twelve minutes of time, to the west of the
-# meridian of the Observatory of Stockholm".  The law is dated 1878-05-31.
-#
-# The observatory at that time had the meridian 18° 03' 30"
-# eastern longitude = 01:12:14 in time.  Less 12 minutes gives the
-# national standard time as 01:00:14 ahead of GMT....
-#
-# About the beginning of CET in Sweden. The lawtext ("Svensk
-# författningssamling 1899, no 44") states, that "from the beginning
-# of 1900... ... the same as the mean solar time for the meridian at
-# the distance of one hour of time from the meridian of the English
-# observatory at Greenwich, or at 12 minutes 14 seconds to the west
-# from the meridian of the Observatory of Stockholm". The law is dated
-# 1899-06-16.  In short: At 1900-01-01 00:00:00 the new standard time
-# in Sweden is 01:00:00 ahead of GMT.
-#
-# 1916: The lawtext ("Svensk författningssamling 1916, no 124") states
-# that "1916-05-15 is considered to begin one hour earlier". It is
-# pretty obvious that at 05-14 23:00 the clocks are set to 05-15 00:00....
-# Further the law says, that "1916-09-30 is considered to end one hour later".
-#
-# The laws regulating [DST] are available on the site of the Swedish
-# Parliament beginning with 1985 - the laws regulating 1980/1984 are
-# not available on the site (to my knowledge they are only available
-# in Swedish): <http://www.riksdagen.se/english/work/sfst.asp> (type
-# "sommartid" without the quotes in the field "Fritext" and then click
-# the Sök-button).
-#
-# (2001-05-13):
-#
-# I have now found a newspaper stating that at 1916-10-01 01:00
-# summertime the church-clocks etc were set back one hour to show
-# 1916-10-01 00:00 standard time.  The article also reports that some
-# people thought the switch to standard time would take place already
-# at 1916-10-01 00:00 summer time, but they had to wait for another
-# hour before the event took place.
-#
-# Source: The newspaper "Dagens Nyheter", 1916-10-01, page 7 upper left.
-
-# An extra-special abbreviation style is SET for Swedish Time (svensk
-# normaltid) 1879-1899, 3° west of the Stockholm Observatory.
-
-# Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1
-			1:00:14	-	SET	1900 Jan  1 # Swedish Time
-			1:00	-	CET	1916 May 14 23:00
-			1:00	1:00	CEST	1916 Oct  1  1:00
-			1:00	-	CET	1980
-			1:00	EU	CE%sT
+# See Europe/Berlin.
 
 # Switzerland
 # From Howse:
@@ -3835,6 +3525,19 @@ Zone Europe/Stockholm	1:12:12 -	LMT	1879 Jan  1
 # 1853-07-16, though it probably occurred at some other date in Zurich, and
 # legal civil time probably changed at still some other transition date.
 
+# From Tobias Conradi (2011-09-12):
+# Büsingen <http://www.buesingen.de>, surrounded by the Swiss canton
+# Schaffhausen, did not start observing DST in 1980 as the rest of DE
+# (West Germany at that time) and DD (East Germany at that time) did.
+# DD merged into DE, the area is currently covered by code DE in ISO 3166-1,
+# which in turn is covered by the zone Europe/Berlin.
+#
+# Source for the time in Büsingen 1980:
+# http://www.srf.ch/player/video?id=c012c029-03b7-4c2b-9164-aa5902cd58d3
+#
+# From Arthur David Olson (2012-03-03):
+# Büsingen and Zurich have shared clocks since 1970.
+
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Swiss	1941	1942	-	May	Mon>=1	1:00	1:00	S
 Rule	Swiss	1941	1942	-	Oct	Mon>=1	2:00	0	-
@@ -3843,6 +3546,9 @@ Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
 			0:29:46	-	BMT	1894 Jun    # Bern Mean Time
 			1:00	Swiss	CE%sT	1981
 			1:00	EU	CE%sT
+Link Europe/Zurich Europe/Busingen
+Link Europe/Zurich Europe/Vaduz
+
 
 # Turkey
 
@@ -4051,7 +3757,7 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 
 # Ukraine
 #
-# From Alois Triendl (2014-03-01):
+# From Alois Treindl (2014-03-01):
 # REGULATION A N O V A on March 20, 1992 N 139 ...  means that from
 # 1992 on, Ukraine had DST with begin time at 02:00 am, on last Sunday
 # in March, and end time 03:00 am, last Sunday in September....
@@ -4111,7 +3817,7 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # The law documents themselves are at
 # http://w1.c1.rada.gov.ua/pls/zweb_n/webproc4_1?id=&pf3511=41484
 
-# From Vladimir in Moscow via Alois Treindl re Kiev time 1991/2 (2014-02-28):
+# From Vladimir in Moscow via Alois Treindl re Kyiv time 1991/2 (2014-02-28):
 # First in Ukraine they changed Time zone from UTC+3 to UTC+2 with DST:
 #       03 25 1990 02:00 -03.00 1       Time Zone 3 with DST
 #       07 01 1990 02:00 -02.00 1       Time Zone 2 with DST
@@ -4139,23 +3845,23 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 # * Ukrainian Government's Resolution of 20.03.1992, No. 139.
 # http://www.uazakon.com/documents/date_8u/pg_grcasa.htm
 
-# From Paul Eggert (2018-10-03):
+# From Paul Eggert (2022-04-12):
 # As is usual in tzdb, Ukrainian zones use the most common English spellings.
-# For example, tzdb uses Europe/Kiev, as "Kiev" is the most common spelling in
-# English for Ukraine's capital, even though it is certainly wrong as a
-# transliteration of the Ukrainian "Київ".  This is similar to tzdb's use of
-# Europe/Prague, which is certainly wrong as a transliteration of the Czech
-# "Praha".  ("Kiev" came from old Slavic via Russian to English, and "Prague"
-# came from old Slavic via French to English, so the two cases have something
-# in common.)  Admittedly English-language spelling of Ukrainian names is
-# controversial, and some day "Kyiv" may become substantially more popular in
-# English; in the meantime, stick with the traditional English "Kiev" as that
-# means less disruption for our users.
+# In particular, tzdb's name Europe/Kyiv uses the most common spelling in
+# English for Ukraine's capital.  Although tzdb's former name was Europe/Kiev,
+# "Kyiv" is now more common due to widespread reporting of the current conflict.
+# Conversely, tzdb continues to use the names Europe/Uzhgorod and
+# Europe/Zaporozhye; this is similar to tzdb's use of Europe/Prague, which is
+# certainly wrong as a transliteration of the Czech "Praha".
+# English-language spelling of Ukrainian names is in flux, and
+# some day "Uzhhorod" or "Zaporizhzhia" may become substantially more
+# common in English; in the meantime, do not change these
+# English spellings as that means less disruption for our users.
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-# This represents most of Ukraine.  See above for the spelling of "Kiev".
-Zone Europe/Kiev	2:02:04 -	LMT	1880
-			2:02:04	-	KMT	1924 May  2 # Kiev Mean Time
+# This represents most of Ukraine.  See above for the spelling of "Kyiv".
+Zone Europe/Kyiv	2:02:04 -	LMT	1880
+			2:02:04	-	KMT	1924 May  2 # Kyiv Mean Time
 			2:00	-	EET	1930 Jun 21
 			3:00	-	MSK	1941 Sep 20
 			1:00	C-Eur	CE%sT	1943 Nov  6
@@ -4178,7 +3884,7 @@ Zone Europe/Uzhgorod	1:29:12 -	LMT	1890 Oct
 			2:00	C-Eur	EE%sT	1996 May 13
 			2:00	EU	EE%sT
 # Zaporozh'ye and eastern Lugansk oblasts observed DST 1990/1991.
-# "Zaporizhia" is the transliteration of the Ukrainian name, but
+# "Zaporizhzhia" is the transliteration of the Ukrainian name, but
 # "Zaporozh'ye" is more common in English.  Use the common English
 # spelling, except omit the apostrophe as it is not allowed in
 # portable Posix file names.

--- a/make/data/tzdata/leapseconds
+++ b/make/data/tzdata/leapseconds
@@ -95,11 +95,11 @@ Leap	2016	Dec	31	23:59:60	+	S
 # Any additional leap seconds will come after this.
 # This Expires line is commented out for now,
 # so that pre-2020a zic implementations do not reject this file.
-#Expires 2022	Dec	28	00:00:00
+#Expires 2023	Jun	28	00:00:00
 
 # POSIX timestamps for the data in this file:
 #updated 1467936000 (2016-07-08 00:00:00 UTC)
-#expires 1672185600 (2022-12-28 00:00:00 UTC)
+#expires 1687910400 (2023-06-28 00:00:00 UTC)
 
-#	Updated through IERS Bulletin C63
-#	File expires on:  28 December 2022
+#	Updated through IERS Bulletin C64
+#	File expires on:  28 June 2023

--- a/make/data/tzdata/northamerica
+++ b/make/data/tzdata/northamerica
@@ -367,8 +367,7 @@ Zone	PST8PDT		 -8:00	US	P%sT
 # From Paul Eggert (2014-09-06):
 # Monthly Notices of the Royal Astronomical Society 44, 4 (1884-02-08), 208
 # says that New York City Hall time was 3 minutes 58.4 seconds fast of
-# Eastern time (i.e., -4:56:01.6) just before the 1883 switch.  Round to the
-# nearest second.
+# Eastern time (i.e., -4:56:01.6) just before the 1883 switch.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER
 Rule	NYC	1920	only	-	Mar	lastSun	2:00	1:00	D
@@ -377,7 +376,8 @@ Rule	NYC	1921	1966	-	Apr	lastSun	2:00	1:00	D
 Rule	NYC	1921	1954	-	Sep	lastSun	2:00	0	S
 Rule	NYC	1955	1966	-	Oct	lastSun	2:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
-Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 12:03:58
+		#STDOFF	-4:56:01.6
+Zone America/New_York	-4:56:02 -	LMT	1883 Nov 18 17:00u
 			-5:00	US	E%sT	1920
 			-5:00	NYC	E%sT	1942
 			-5:00	US	E%sT	1946
@@ -2841,7 +2841,7 @@ Zone America/Tijuana	-7:48:04 -	LMT	1922 Jan  1  0:11:56
 
 # Barbados
 
-# For 1899 Milne gives -3:58:29.2; round that.
+# For 1899 Milne gives -3:58:29.2.
 
 # From P Chan (2020-12-09 and 2020-12-11):
 # Standard time of GMT-4 was adopted in 1911.
@@ -2885,6 +2885,7 @@ Rule	Barb	1978	1980	-	Apr	Sun>=15	2:00	1:00	D
 Rule	Barb	1979	only	-	Sep	30	2:00	0	S
 Rule	Barb	1980	only	-	Sep	25	2:00	0	S
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-3:58:29.2
 Zone America/Barbados	-3:58:29 -	LMT	1911 Aug 28 # Bridgetown
 			-4:00	Barb	A%sT	1944
 			-4:00	Barb	AST/-0330 1945
@@ -2945,10 +2946,10 @@ Zone	America/Belize	-5:52:48 -	LMT	1912 Apr  1
 
 # Bermuda
 
-# From Paul Eggert (2020-11-24):
+# From Paul Eggert (2022-07-27):
 # For 1899 Milne gives -4:19:18.3 as the meridian of the clock tower,
 # Bermuda dockyard, Ireland I.  This agrees with standard offset given in the
-# Daylight Saving Act, 1917 cited below.  Round that to the nearest second.
+# Daylight Saving Act, 1917 cited below.
 # It is not known when this time became standard for Bermuda; guess 1890.
 # The transition to -04 was specified by:
 # 1930: The Time Zone Act, 1929 (1929: No. 39) [1929-11-08]
@@ -3043,6 +3044,7 @@ Rule	Bermuda	1956	only	-	May	Sun>=22	 2:00	1:00	D
 Rule	Bermuda	1956	only	-	Oct	lastSun	 2:00	0	S
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-4:19:18.3
 Zone Atlantic/Bermuda	-4:19:18 -	LMT	1890	# Hamilton
 			-4:19:18 Bermuda BMT/BST 1930 Jan 1  2:00
 			-4:00	Bermuda	A%sT	1974 Apr 28  2:00
@@ -3057,7 +3059,7 @@ Zone Atlantic/Bermuda	-4:19:18 -	LMT	1890	# Hamilton
 
 # Costa Rica
 
-# Milne gives -5:36:13.3 as San José mean time; round to nearest.
+# Milne gives -5:36:13.3 as San José mean time.
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	CR	1979	1980	-	Feb	lastSun	0:00	1:00	D
@@ -3069,6 +3071,7 @@ Rule	CR	1991	only	-	Jul	 1	0:00	0	S
 Rule	CR	1992	only	-	Mar	15	0:00	0	S
 # There are too many San Josés elsewhere, so we'll use 'Costa Rica'.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-5:36:13.3
 Zone America/Costa_Rica	-5:36:13 -	LMT	1890        # San José
 			-5:36:13 -	SJMT	1921 Jan 15 # San José Mean Time
 			-6:00	CR	C%sT
@@ -3491,7 +3494,7 @@ Zone America/Tegucigalpa -5:48:52 -	LMT	1921 Apr
 # Jamaica
 # Shanks & Pottenger give -5:07:12, but Milne records -5:07:10.41 from an
 # unspecified official document, and says "This time is used throughout the
-# island".  Go with Milne.  Round to the nearest second as required by zic.
+# island".  Go with Milne.
 #
 # Shanks & Pottenger give April 28 for the 1974 spring-forward transition, but
 # Lance Neita writes that Prime Minister Michael Manley decreed it January 5.
@@ -3504,6 +3507,7 @@ Zone America/Tegucigalpa -5:48:52 -	LMT	1921 Apr
 # http://www.jamaicaobserver.com/columns/The-politician-in-all-of-us_17573647
 #
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-5:07:10.41
 Zone	America/Jamaica	-5:07:10 -	LMT	1890        # Kingston
 			-5:07:10 -	KMT	1912 Feb    # Kingston Mean Time
 			-5:00	-	EST	1974
@@ -3701,6 +3705,7 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
 Zone America/Grand_Turk	-4:44:32 -	LMT	1890
+		#STDOFF	-5:07:10.41
 			-5:07:10 -	KMT	1912 Feb # Kingston Mean Time
 			-5:00	-	EST	1979
 			-5:00	US	E%sT	2015 Mar  8  2:00

--- a/make/data/tzdata/southamerica
+++ b/make/data/tzdata/southamerica
@@ -423,6 +423,7 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	-
 #
 # Buenos Aires (BA), Capital Federal (CF),
 Zone America/Argentina/Buenos_Aires -3:53:48 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May    # Córdoba Mean Time
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -440,6 +441,7 @@ Zone America/Argentina/Buenos_Aires -3:53:48 - LMT	1894 Oct 31
 # - Santiago del Estero switched to -4:00 on 1991-04-01,
 #   then to -3:00 on 1991-04-26.
 #
+		#STDOFF	       -4:16:48.25
 Zone America/Argentina/Cordoba -4:16:48 - LMT	1894 Oct 31
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
@@ -452,6 +454,7 @@ Zone America/Argentina/Cordoba -4:16:48 - LMT	1894 Oct 31
 #
 # Salta (SA), La Pampa (LP), Neuquén (NQ), Rio Negro (RN)
 Zone America/Argentina/Salta -4:21:40 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -464,6 +467,7 @@ Zone America/Argentina/Salta -4:21:40 - LMT	1894 Oct 31
 #
 # Tucumán (TM)
 Zone America/Argentina/Tucuman -4:20:52 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -477,6 +481,7 @@ Zone America/Argentina/Tucuman -4:20:52 - LMT	1894 Oct 31
 #
 # La Rioja (LR)
 Zone America/Argentina/La_Rioja -4:27:24 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -491,6 +496,7 @@ Zone America/Argentina/La_Rioja -4:27:24 - LMT	1894 Oct 31
 #
 # San Juan (SJ)
 Zone America/Argentina/San_Juan -4:34:04 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -505,6 +511,7 @@ Zone America/Argentina/San_Juan -4:34:04 - LMT	1894 Oct 31
 #
 # Jujuy (JY)
 Zone America/Argentina/Jujuy -4:21:12 -	LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -520,6 +527,7 @@ Zone America/Argentina/Jujuy -4:21:12 -	LMT	1894 Oct 31
 #
 # Catamarca (CT), Chubut (CH)
 Zone America/Argentina/Catamarca -4:23:08 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -534,6 +542,7 @@ Zone America/Argentina/Catamarca -4:23:08 - LMT	1894 Oct 31
 #
 # Mendoza (MZ)
 Zone America/Argentina/Mendoza -4:35:16 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -556,6 +565,7 @@ Rule	SanLuis	2008	2009	-	Mar	Sun>=8	0:00	0	-
 Rule	SanLuis	2007	2008	-	Oct	Sun>=8	0:00	1:00	-
 
 Zone America/Argentina/San_Luis -4:25:24 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -574,6 +584,7 @@ Zone America/Argentina/San_Luis -4:25:24 - LMT	1894 Oct 31
 #
 # Santa Cruz (SC)
 Zone America/Argentina/Rio_Gallegos -4:36:52 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -586,6 +597,7 @@ Zone America/Argentina/Rio_Gallegos -4:36:52 - LMT	1894 Oct 31
 #
 # Tierra del Fuego, Antártida e Islas del Atlántico Sur (TF)
 Zone America/Argentina/Ushuaia -4:33:12 - LMT	1894 Oct 31
+		#STDOFF	-4:16:48.25
 			-4:16:48 -	CMT	1920 May
 			-4:00	-	-04	1930 Dec
 			-4:00	Arg	-04/-03	1969 Oct  5
@@ -668,7 +680,7 @@ Zone	America/La_Paz	-4:32:36 -	LMT	1890
 
 # From Rodrigo Severo (2004-10-04):
 # It's just the biannual change made necessary by the much hyped, supposedly
-# modern Brazilian eletronic voting machines which, apparently, can't deal
+# modern Brazilian ... voting machines which, apparently, can't deal
 # with a time change between the first and the second rounds of the elections.
 
 # From Steffen Thorsen (2007-09-20):
@@ -1164,7 +1176,7 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # this is known to work for DST transitions starting in 2008 and
 # may well be true for earlier transitions.
 
-# From Tim Parenti (2022-03-15):
+# From Tim Parenti (2022-07-06):
 # For a brief period of roughly six weeks in 1946, DST was only observed on an
 # emergency basis in specific regions of central Chile; namely, "the national
 # territory between the provinces of Coquimbo and Concepción, inclusive".
@@ -1182,7 +1194,14 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # Law Number 8,522, promulgated 1946-08-27, reunified Chilean clocks at their
 # new "Summer Time" of -04, reckoned as that of "the meridian of the
 # Astronomical Observatory of Lo Espejo, advanced by 42 minutes and 45
-# seconds".
+# seconds".  Although this law specified the new Summer Time to start on 1
+# September each year, a special "transitional article" started it a few days
+# early, as soon as the law took effect.  As the law was to take force "from
+# the date of its publication in the 'Diario Oficial', which happened the
+# following day, presume the change took place in Santiago and its environs
+# from 24:00 -03 to 23:00 -04 on Wednesday 1946-08-28.  Although this was a
+# no-op for wall clocks in the north and south of the country, put their formal
+# start to DST an hour later when they reached 24:00 -04.
 # https://www.diariooficial.interior.gob.cl/versiones-anteriores/do-h/19460828/#page/1
 # After a brief "Winter Time" stint at -05 beginning 1947-04-01, Law Number
 # 8,777, promulgated 1947-05-17, established year-round -04 "from 23:00 on the
@@ -1302,11 +1321,19 @@ Zone America/Rio_Branco	-4:31:12 -	LMT	1914
 # So we extend the new rules on Saturdays at 24:00 mainland time indefinitely.
 # From Juan Correa (2019-02-04):
 # http://www.diariooficial.interior.gob.cl/publicaciones/2018/11/23/42212/01/1498738.pdf
-# From Paul Eggert (2019-09-01):
-# The above says the Magallanes exception expires 2022-04-02 at 24:00,
-# so in theory, they will revert to -04/-03 after that.
-# For now, assume that they will not revert,
-# since they have extended the expiration date once already.
+
+# From Juan Correa (2022-04-02):
+# I found there was a decree published last Thursday that will keep
+# Magallanes region to UTC -3 "indefinitely". The decree is available at
+# https://www.diariooficial.interior.gob.cl/publicaciones/2022/03/31/43217-B/01/2108910.pdf
+
+# From Juan Correa (2022-08-09):
+# the Internal Affairs Ministry (Ministerio del Interior) informed DST
+# for America/Santiago will start on midnight of September 11th;
+# and will end on April 1st, 2023. Magallanes region (America/Punta_Arenas)
+# will keep UTC -3 "indefinitely"...  This is because on September 4th
+# we will have a voting whether to approve a new Constitution....
+# https://www.interior.gob.cl/noticias/2022/08/09/comunicado-el-proximo-sabado-10-de-septiembre-los-relojes-se-deben-adelantar-una-hora/
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	Chile	1927	1931	-	Sep	 1	0:00	1:00	-
@@ -1344,7 +1371,9 @@ Rule	Chile	2012	2014	-	Sep	Sun>=2	4:00u	1:00	-
 Rule	Chile	2016	2018	-	May	Sun>=9	3:00u	0	-
 Rule	Chile	2016	2018	-	Aug	Sun>=9	4:00u	1:00	-
 Rule	Chile	2019	max	-	Apr	Sun>=2	3:00u	0	-
-Rule	Chile	2019	max	-	Sep	Sun>=2	4:00u	1:00	-
+Rule	Chile	2019	2021	-	Sep	Sun>=2	4:00u	1:00	-
+Rule	Chile	2022	only	-	Sep	Sun>=9	4:00u	1:00	-
+Rule	Chile	2023	max	-	Sep	Sun>=2	4:00u	1:00	-
 # IATA SSIM anomalies: (1992-02) says 1992-03-14;
 # (1996-09) says 1998-03-08.  Ignore these.
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
@@ -1357,9 +1386,9 @@ Zone America/Santiago	-4:42:45 -	LMT	1890
 			-5:00	Chile	-05/-04	1932 Sep  1
 			-4:00	-	-04	1942 Jun  1
 			-5:00	-	-05	1942 Aug  1
-			-4:00	-	-04	1946 Jul 15
-			-4:00	1:00	-03	1946 Sep  1 # central Chile
-			-4:00	-	-04	1947 Apr  1
+			-4:00	-	-04	1946 Jul 14 24:00
+			-4:00	1:00	-03	1946 Aug 28 24:00 # central CL
+			-5:00	1:00	-04	1947 Mar 31 24:00
 			-5:00	-	-05	1947 May 21 23:00
 			-4:00	Chile	-04/-03
 Zone America/Punta_Arenas -4:43:40 -	LMT	1890
@@ -1371,7 +1400,8 @@ Zone America/Punta_Arenas -4:43:40 -	LMT	1890
 			-5:00	Chile	-05/-04	1932 Sep  1
 			-4:00	-	-04	1942 Jun  1
 			-5:00	-	-05	1942 Aug  1
-			-4:00	-	-04	1947 Apr  1
+			-4:00	-	-04	1946 Aug 28 24:00
+			-5:00	1:00	-04	1947 Mar 31 24:00
 			-5:00	-	-05	1947 May 21 23:00
 			-4:00	Chile	-04/-03	2016 Dec  4
 			-3:00	-	-03
@@ -1405,13 +1435,14 @@ Zone Antarctica/Palmer	0	-	-00	1965
 
 # Colombia
 
-# Milne gives 4:56:16.4 for Bogotá time in 1899; round to nearest.  He writes,
+# Milne gives 4:56:16.4 for Bogotá time in 1899.  He writes,
 # "A variation of fifteen minutes in the public clocks of Bogota is not rare."
 
 # Rule	NAME	FROM	TO	-	IN	ON	AT	SAVE	LETTER/S
 Rule	CO	1992	only	-	May	 3	0:00	1:00	-
 Rule	CO	1993	only	-	Apr	 4	0:00	0	-
 # Zone	NAME		STDOFF	RULES	FORMAT	[UNTIL]
+		#STDOFF	-4:56:16.4
 Zone	America/Bogota	-4:56:16 -	LMT	1884 Mar 13
 			-4:56:16 -	BMT	1914 Nov 23 # Bogotá Mean Time
 			-5:00	CO	-05/-04

--- a/make/data/tzdata/zone.tab
+++ b/make/data/tzdata/zone.tab
@@ -153,7 +153,7 @@ CA	+690650-1050310	America/Cambridge_Bay	Mountain - NU (west)
 CA	+6227-11421	America/Yellowknife	Mountain - NT (central)
 CA	+682059-1334300	America/Inuvik	Mountain - NT (west)
 CA	+4906-11631	America/Creston	MST - BC (Creston)
-CA	+5946-12014	America/Dawson_Creek	MST - BC (Dawson Cr, Ft St John)
+CA	+5546-12014	America/Dawson_Creek	MST - BC (Dawson Cr, Ft St John)
 CA	+5848-12242	America/Fort_Nelson	MST - BC (Ft Nelson)
 CA	+6043-13503	America/Whitehorse	MST - Yukon (east)
 CA	+6404-13925	America/Dawson	MST - Yukon (west)
@@ -423,7 +423,7 @@ TT	+1039-06131	America/Port_of_Spain
 TV	-0831+17913	Pacific/Funafuti
 TW	+2503+12130	Asia/Taipei
 TZ	-0648+03917	Africa/Dar_es_Salaam
-UA	+5026+03031	Europe/Kiev	Ukraine (most areas)
+UA	+5026+03031	Europe/Kyiv	Ukraine (most areas)
 UA	+4837+02218	Europe/Uzhgorod	Transcarpathia
 UA	+4750+03510	Europe/Zaporozhye	Zaporozhye and east Lugansk
 UG	+0019+03225	Africa/Kampala

--- a/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/VERSION
@@ -1,1 +1,1 @@
-tzdata2022a
+tzdata2022c

--- a/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/aliases.txt
@@ -7,6 +7,7 @@ Link Africa/Abidjan Africa/Freetown	# Sierra Leone
 Link Africa/Abidjan Africa/Lome		# Togo
 Link Africa/Abidjan Africa/Nouakchott	# Mauritania
 Link Africa/Abidjan Africa/Ouagadougou	# Burkina Faso
+Link Africa/Abidjan Atlantic/Reykjavik	# Iceland
 Link Africa/Abidjan Atlantic/St_Helena	# St Helena
 Link Africa/Nairobi Africa/Addis_Ababa	 # Ethiopia
 Link Africa/Nairobi Africa/Asmara	 # Eritrea
@@ -35,33 +36,53 @@ Link Africa/Lagos Africa/Niamey		# Niger
 Link Africa/Lagos Africa/Porto-Novo	# Benin
 Link Africa/Johannesburg Africa/Maseru	# Lesotho
 Link Africa/Johannesburg Africa/Mbabane	# Eswatini
+Link Asia/Yangon Indian/Cocos
+Link Asia/Urumqi Antarctica/Vostok
 Link	Asia/Nicosia	Europe/Nicosia
+Link Asia/Kuching Asia/Brunei
+Link Indian/Maldives Indian/Kerguelen
 Link Asia/Qatar Asia/Bahrain
 Link Asia/Riyadh Antarctica/Syowa
 Link Asia/Riyadh Asia/Aden	# Yemen
 Link Asia/Riyadh Asia/Kuwait
+Link Asia/Singapore Asia/Kuala_Lumpur
 Link Asia/Bangkok Asia/Phnom_Penh	# Cambodia
 Link Asia/Bangkok Asia/Vientiane	# Laos
+Link Asia/Bangkok Indian/Christmas
 Link Asia/Dubai Asia/Muscat	# Oman
+Link Asia/Dubai Indian/Mahe
+Link Asia/Dubai Indian/Reunion
 Link Pacific/Guam Pacific/Saipan # N Mariana Is
+Link Pacific/Tarawa Pacific/Funafuti
+Link Pacific/Tarawa Pacific/Majuro
+Link Pacific/Tarawa Pacific/Wake
+Link Pacific/Tarawa Pacific/Wallis
 Link Pacific/Auckland Antarctica/McMurdo
 Link Pacific/Port_Moresby Antarctica/DumontDUrville
+Link Pacific/Port_Moresby Pacific/Chuuk
 Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
+Link Pacific/Guadalcanal Pacific/Pohnpei
 Link	Europe/London	Europe/Jersey
 Link	Europe/London	Europe/Guernsey
 Link	Europe/London	Europe/Isle_of_Man
+Link Europe/Brussels Europe/Amsterdam
+Link Europe/Brussels Europe/Luxembourg
+Link Europe/Prague Europe/Bratislava
 Link	Europe/Helsinki	Europe/Mariehamn
-Link	Europe/Zurich	Europe/Busingen
-Link	Europe/Rome	Europe/Vatican
-Link	Europe/Rome	Europe/San_Marino
-Link Europe/Zurich Europe/Vaduz
-Link	Europe/Oslo	Arctic/Longyearbyen
+Link Europe/Paris Europe/Monaco
+Link Europe/Berlin Arctic/Longyearbyen
+Link Europe/Berlin Europe/Copenhagen
+Link Europe/Berlin Europe/Oslo
+Link Europe/Berlin Europe/Stockholm
+Link Europe/Rome Europe/Vatican
+Link Europe/Rome Europe/San_Marino
 Link Europe/Belgrade Europe/Ljubljana	# Slovenia
 Link Europe/Belgrade Europe/Podgorica	# Montenegro
 Link Europe/Belgrade Europe/Sarajevo	# Bosnia and Herzegovina
 Link Europe/Belgrade Europe/Skopje	# North Macedonia
 Link Europe/Belgrade Europe/Zagreb	# Croatia
-Link Europe/Prague Europe/Bratislava
+Link Europe/Zurich Europe/Busingen
+Link Europe/Zurich Europe/Vaduz
 Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 Link America/Phoenix America/Creston
 Link America/Toronto America/Nassau
@@ -128,7 +149,7 @@ Link	Asia/Thimphu		Asia/Thimbu
 Link	Asia/Makassar		Asia/Ujung_Pandang
 Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
 Link	Atlantic/Faroe		Atlantic/Faeroe
-Link	Europe/Oslo		Atlantic/Jan_Mayen
+Link	Europe/Berlin		Atlantic/Jan_Mayen
 Link	Australia/Sydney	Australia/ACT
 Link	Australia/Sydney	Australia/Canberra
 Link	Australia/Hobart	Australia/Currie
@@ -160,6 +181,7 @@ Link	Africa/Cairo		Egypt
 Link	Europe/Dublin		Eire
 Link	Etc/UTC			Etc/UCT
 Link	Europe/London		Europe/Belfast
+Link	Europe/Kyiv		Europe/Kiev
 Link	Europe/Chisinau		Europe/Tiraspol
 Link	Europe/London		GB
 Link	Europe/London		GB-Eire
@@ -168,7 +190,7 @@ Link	Etc/GMT			GMT-0
 Link	Etc/GMT			GMT0
 Link	Etc/GMT			Greenwich
 Link	Asia/Hong_Kong		Hongkong
-Link	Atlantic/Reykjavik	Iceland
+Link	Africa/Abidjan		Iceland
 Link	Asia/Tehran		Iran
 Link	Asia/Jerusalem		Israel
 Link	America/Jamaica		Jamaica
@@ -184,10 +206,10 @@ Link	America/Denver		Navajo
 Link	Asia/Shanghai		PRC
 Link	Pacific/Kanton		Pacific/Enderbury
 Link	Pacific/Honolulu	Pacific/Johnston
-Link	Pacific/Pohnpei		Pacific/Ponape
+Link	Pacific/Guadalcanal	Pacific/Ponape
 Link	Pacific/Pago_Pago	Pacific/Samoa
-Link	Pacific/Chuuk		Pacific/Truk
-Link	Pacific/Chuuk		Pacific/Yap
+Link	Pacific/Port_Moresby	Pacific/Truk
+Link	Pacific/Port_Moresby	Pacific/Yap
 Link	Europe/Warsaw		Poland
 Link	Europe/Lisbon		Portugal
 Link	Asia/Taipei		ROC

--- a/test/jdk/java/util/TimeZone/TimeZoneData/displaynames.txt
+++ b/test/jdk/java/util/TimeZone/TimeZoneData/displaynames.txt
@@ -97,7 +97,6 @@ America/Winnipeg CST CDT
 America/Yakutat AKST AKDT
 America/Yellowknife MST MDT
 Antarctica/Macquarie AEST AEDT
-Antarctica/Troll UTC
 Asia/Amman EET EEST
 Asia/Beirut EET EEST
 Asia/Damascus EET EEST
@@ -124,7 +123,6 @@ Atlantic/Bermuda AST ADT
 Atlantic/Canary WET WEST
 Atlantic/Faroe WET WEST
 Atlantic/Madeira WET WEST
-Atlantic/Reykjavik GMT
 Australia/Adelaide ACST ACDT
 Australia/Brisbane AEST AEDT
 Australia/Broken_Hill ACST ACDT
@@ -139,7 +137,6 @@ CST6CDT CST CDT
 EET EET EEST
 EST EST
 EST5EDT EST EDT
-Europe/Amsterdam CET CEST
 Europe/Andorra CET CEST
 Europe/Athens EET EEST
 Europe/Belgrade CET CEST
@@ -148,27 +145,22 @@ Europe/Brussels CET CEST
 Europe/Bucharest EET EEST
 Europe/Budapest CET CEST
 Europe/Chisinau EET EEST
-Europe/Copenhagen CET CEST
 Europe/Dublin IST/GMT IST/GMT
 Europe/Gibraltar CET CEST
 Europe/Helsinki EET EEST
 Europe/Kaliningrad EET
-Europe/Kiev EET EEST
+Europe/Kyiv EET EEST
 Europe/Lisbon WET WEST
 Europe/London GMT/BST GMT/BST
-Europe/Luxembourg CET CEST
 Europe/Madrid CET CEST
 Europe/Malta CET CEST
-Europe/Monaco CET CEST
 Europe/Moscow MSK
-Europe/Oslo CET CEST
 Europe/Paris CET CEST
 Europe/Prague CET CEST
 Europe/Riga EET EEST
 Europe/Rome CET CEST
 Europe/Simferopol MSK
 Europe/Sofia EET EEST
-Europe/Stockholm CET CEST
 Europe/Tallinn EET EEST
 Europe/Tirane CET CEST
 Europe/Uzhgorod EET EEST

--- a/test/jdk/java/util/TimeZone/tools/share/Makefile
+++ b/test/jdk/java/util/TimeZone/tools/share/Makefile
@@ -1,12 +1,10 @@
 #
-# Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the LICENSE file that accompanied this code.
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -23,42 +21,38 @@
 # questions.
 #
 
-###
-### This file is just a very small wrapper needed to run the real make/Init.gmk.
-### It also performs some sanity checks on make.
-###
+#
+#
+# This makefile is used to update the time zone tests data: aliases.txt displaynames.txt
+# and VERSION. After switching to new build system in JDK8 the following make
+# command should be used for test data updates:
+#     make JDK_HOME=<path to built JDK with latest tzdata>
+#     make install
+#
 
-# The shell code below will be executed on /usr/bin/make on Solaris, but not in GNU Make.
-# /usr/bin/make lacks basically every other flow control mechanism.
-.TEST_FOR_NON_GNUMAKE:sh=echo You are not using GNU Make/gmake, this is a requirement. Check your path. 1>&2 && exit 1
+TZDATA = ../../../../../../../make/data/tzdata
+TZDATA_VER = `grep '^tzdata' $(TZDATA)/VERSION`
+TZNAME = africa antarctica asia australasia europe northamerica \
+	solar87 solar88 solar89 southamerica \
+	backward
+TZFILES = $(addprefix $(TZDATA)/, $(TZNAME))
+ALIASLIST = aliases.txt
+DISPLAYNAMES = displaynames.txt
 
-# The .FEATURES variable is likely to be unique for GNU Make.
-ifeq ($(.FEATURES), )
-  $(info Error: '$(MAKE)' does not seem to be GNU Make, which is a requirement.)
-  $(info Check your path, or upgrade to GNU Make 3.81 or newer.)
-  $(error Cannot continue)
-endif
+all:	$(DISPLAYNAMES) VERSION $(ALIASLIST)
 
-# Assume we have GNU Make, but check version.
-ifeq ($(strip $(foreach v, 3.81% 3.82% 4.%, $(filter $v, $(MAKE_VERSION)))), )
-  $(info Error: This version of GNU Make is too low ($(MAKE_VERSION)).)
-  $(info Check your path, or upgrade to GNU Make 3.81 or newer.)
-  $(error Cannot continue)
-endif
+$(DISPLAYNAMES): $(TZFILES) makeZoneData.pl
+	(cat $(TZFILES) | perl makeZoneData.pl -v -V "$(TZDATA_VER)") 2>errors
 
-# In Cygwin, the MAKE variable gets prepended with the current directory if the
-# make executable is called using a Windows mixed path (c:/cygwin/bin/make.exe).
-ifneq ($(findstring :, $(MAKE)), )
-  MAKE := $(patsubst $(CURDIR)%, %, $(patsubst $(CURDIR)/%, %, $(MAKE)))
-endif
+VERSION: $(TZDATA)/VERSION
+	echo "$(TZDATA_VER)" > VERSION
 
-# Locate this Makefile
-ifeq ($(filter /%, $(lastword $(MAKEFILE_LIST))),)
-  makefile_path := $(CURDIR)/$(strip $(lastword $(MAKEFILE_LIST)))
-else
-  makefile_path := $(lastword $(MAKEFILE_LIST))
-endif
-topdir := $(strip $(patsubst %/, %, $(dir $(makefile_path))))
+$(ALIASLIST): $(TZFILES)
+	rm -f $(ALIASLIST)
+	grep -h "^Link" $(TZFILES) >> $(ALIASLIST)
 
-# ... and then we can include the real makefile
-include $(topdir)/make/Init.gmk
+clean:
+	rm -f $(DISPLAYNAMES) errors year???? VERSION $(ALIASLIST)
+
+install:
+	cp $(ALIASLIST) $(DISPLAYNAMES) VERSION ../../TimeZoneData/

--- a/test/jdk/java/util/TimeZone/tools/share/Makefile
+++ b/test/jdk/java/util/TimeZone/tools/share/Makefile
@@ -1,10 +1,12 @@
 #
-# Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -21,38 +23,42 @@
 # questions.
 #
 
-#
-#
-# This makefile is used to update the time zone tests data: aliases.txt displaynames.txt
-# and VERSION. After switching to new build system in JDK8 the following make
-# command should be used for test data updates:
-#     make JDK_HOME=<path to built JDK with latest tzdata>
-#     make install
-#
+###
+### This file is just a very small wrapper needed to run the real make/Init.gmk.
+### It also performs some sanity checks on make.
+###
 
-TZDATA = ../../../../../../../src/java.base/share/data/tzdata
-TZDATA_VER = `grep '^tzdata' $(TZDATA)/VERSION`
-TZNAME = africa antarctica asia australasia europe northamerica \
-	solar87 solar88 solar89 southamerica \
-	backward
-TZFILES = $(addprefix $(TZDATA)/, $(TZNAME))
-ALIASLIST = aliases.txt
-DISPLAYNAMES = displaynames.txt
+# The shell code below will be executed on /usr/bin/make on Solaris, but not in GNU Make.
+# /usr/bin/make lacks basically every other flow control mechanism.
+.TEST_FOR_NON_GNUMAKE:sh=echo You are not using GNU Make/gmake, this is a requirement. Check your path. 1>&2 && exit 1
 
-all:	$(DISPLAYNAMES) VERSION $(ALIASLIST)
+# The .FEATURES variable is likely to be unique for GNU Make.
+ifeq ($(.FEATURES), )
+  $(info Error: '$(MAKE)' does not seem to be GNU Make, which is a requirement.)
+  $(info Check your path, or upgrade to GNU Make 3.81 or newer.)
+  $(error Cannot continue)
+endif
 
-$(DISPLAYNAMES): $(TZFILES) makeZoneData.pl
-	(cat $(TZFILES) | perl makeZoneData.pl -v -V "$(TZDATA_VER)") 2>errors
+# Assume we have GNU Make, but check version.
+ifeq ($(strip $(foreach v, 3.81% 3.82% 4.%, $(filter $v, $(MAKE_VERSION)))), )
+  $(info Error: This version of GNU Make is too low ($(MAKE_VERSION)).)
+  $(info Check your path, or upgrade to GNU Make 3.81 or newer.)
+  $(error Cannot continue)
+endif
 
-VERSION: $(TZDATA)/VERSION
-	echo "$(TZDATA_VER)" > VERSION
+# In Cygwin, the MAKE variable gets prepended with the current directory if the
+# make executable is called using a Windows mixed path (c:/cygwin/bin/make.exe).
+ifneq ($(findstring :, $(MAKE)), )
+  MAKE := $(patsubst $(CURDIR)%, %, $(patsubst $(CURDIR)/%, %, $(MAKE)))
+endif
 
-$(ALIASLIST): $(TZFILES)
-	rm -f $(ALIASLIST)
-	grep -h "^Link" $(TZFILES) >> $(ALIASLIST)
+# Locate this Makefile
+ifeq ($(filter /%, $(lastword $(MAKEFILE_LIST))),)
+  makefile_path := $(CURDIR)/$(strip $(lastword $(MAKEFILE_LIST)))
+else
+  makefile_path := $(lastword $(MAKEFILE_LIST))
+endif
+topdir := $(strip $(patsubst %/, %, $(dir $(makefile_path))))
 
-clean:
-	rm -f $(DISPLAYNAMES) errors year???? VERSION $(ALIASLIST)
-
-install:
-	cp $(ALIASLIST) $(DISPLAYNAMES) VERSION ../../TimeZoneData/
+# ... and then we can include the real makefile
+include $(topdir)/make/Init.gmk


### PR DESCRIPTION
Slightly adapted backport of Timezone Data update 2022c. Data in 15u are still in make/ subdirectory, so the paths are changed. Also this path specifics is recorded in test/jdk/java/util/TimeZone/tools/share/Makefile.
All relevant tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292579](https://bugs.openjdk.org/browse/JDK-8292579): (tz) Update Timezone Data to 2022c


### Reviewers
 * [Andrew Brygin](https://openjdk.org/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/277/head:pull/277` \
`$ git checkout pull/277`

Update a local copy of the PR: \
`$ git checkout pull/277` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 277`

View PR using the GUI difftool: \
`$ git pr show -t 277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/277.diff">https://git.openjdk.org/jdk15u-dev/pull/277.diff</a>

</details>
