### PR TITLE
8272720: Fix the implementation of loop unrolling heuristic with LoopPercentProfileLimit

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -800,7 +800,7 @@ bool IdealLoopTree::policy_unroll(PhaseIdealLoop *phase) {
   //   Progress defined as current size less than 20% larger than previous size.
   if (UseSuperWord && cl->node_count_before_unroll() > 0 &&
       future_unroll_cnt > LoopUnrollMin &&
-      (future_unroll_cnt - 1) * (100 / LoopPercentProfileLimit) > cl->profile_trip_cnt() &&
+      (future_unroll_cnt - 1) * (100.0 / LoopPercentProfileLimit) > cl->profile_trip_cnt() &&
       1.2 * cl->node_count_before_unroll() < (double)_body.size()) {
     return false;
   }


### PR DESCRIPTION
Backport of JDK-8272720 to 15u
Applied cleanely, no tier1 tests regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272720](https://bugs.openjdk.org/browse/JDK-8272720): Fix the implementation of loop unrolling heuristic with LoopPercentProfileLimit


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/278.diff">https://git.openjdk.org/jdk15u-dev/pull/278.diff</a>

</details>
