### PR TITLE
Backport a1c942c02b65a7fc2a837d2bb43fa134dadcad11

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -533,9 +533,8 @@ void Dictionary::verify() {
   ClassLoaderData* cld = loader_data();
   // class loader must be present;  a null class loader is the
   // boostrap loader
-  guarantee(cld != NULL ||
-            cld->class_loader() == NULL ||
-            cld->class_loader()->is_instance(),
+  guarantee(cld != NULL &&
+            (cld->the_null_class_loader_data() || cld->class_loader()->is_instance()),
             "checking type of class_loader");
 
   ResourceMark rm;


### PR DESCRIPTION
Backport of JDK-8272720 to 15u
Applied cleanely, no tier1 tests regressions.