### PR TITLE
8266171: -Warray-bounds happens in imageioJPEG.c

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -341,7 +341,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVAJPEG, \
     OPTIMIZATION := HIGHEST, \
     CFLAGS := $(CFLAGS_JDKLIB), \
     HEADERS_FROM_SRC := $(LIBJPEG_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := clobbered implicit-fallthrough shift-negative-value, \
+    DISABLED_WARNINGS_gcc := clobbered implicit-fallthrough shift-negative-value array-bounds, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LIBS := $(LIBJPEG_LIBS) $(JDKLIB_LIBS), \


### PR DESCRIPTION
Backport JDK-8266171
Clean backport, no tier1 regression

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266171](https://bugs.openjdk.org/browse/JDK-8266171): -Warray-bounds happens in imageioJPEG.c


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/284/head:pull/284` \
`$ git checkout pull/284`

Update a local copy of the PR: \
`$ git checkout pull/284` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 284`

View PR using the GUI difftool: \
`$ git pr show -t 284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/284.diff">https://git.openjdk.org/jdk15u-dev/pull/284.diff</a>

</details>
