### PR TITLE
8295429: Update harfbuzz md file

### DIFF
--- a/src/java.desktop/share/legal/harfbuzz.md
+++ b/src/java.desktop/share/legal/harfbuzz.md
@@ -2,7 +2,7 @@
 
 ### Harfbuzz License
 
-https://github.com/harfbuzz/harfbuzz/blob/master/COPYING
+https://github.com/harfbuzz/harfbuzz/blob/4.4.1/COPYING
 
 <pre>
 
@@ -10,19 +10,23 @@ HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
 For parts of HarfBuzz that are licensed under different licenses see individual
 files names COPYING in subdirectories where applicable.
 
-Copyright © 2010,2011,2012,2013,2014,2015,2016,2017,2018,2019,2020  Google, Inc.
-Copyright © 2018,2019,2020  Ebrahim Byagowi
-Copyright © 2019,2020  Facebook, Inc. 
-Copyright © 2012  Mozilla Foundation
+Copyright © 2010-2022  Google, Inc.
+Copyright © 2018-2020  Ebrahim Byagowi
+Copyright © 2019-2020  Facebook, Inc.
+Copyright © 2012-2015  Mozilla Foundation.
 Copyright © 2011  Codethink Limited
-Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
+Copyright © 2008-2010  Nokia Corporation and/or its subsidiary(-ies)
 Copyright © 2009  Keith Stribley
 Copyright © 2009  Martin Hosken and SIL International
 Copyright © 2007  Chris Wilson
-Copyright © 2006  Behdad Esfahbod
+Copyright © 2005-2022 Behdad Esfahbod
 Copyright © 2005  David Turner
-Copyright © 2004,2007,2008,2009,2010  Red Hat, Inc.
+Copyright © 2004-2013  Red Hat, Inc.
 Copyright © 1998-2004  David Turner and Werner Lemberg
+Copyright © 2016  Elie Roux <elie.roux@telecom-bretagne.eu>
+Copyright © 2018-2019 Adobe Inc.
+Copyright © 2018  Khaled Hosny
+Copyright © 2016  Igalia S.L.
 
 For full copyright notices consult the individual files in the package.
 
@@ -48,6 +52,10 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 All source code, except for one section, is licensed as above. The one
 exception is licensed with a slightly different MIT variant:
 The contents of this directory are licensed under the following terms:
+
+---------------------------------
+The below license applies to the following files:
+libharfbuzz/hb-ucd.cc
 
 Copyright (C) 2012 Grigori Goronzy <greg@kinoho.net>
 


### PR DESCRIPTION
backporting for parity with other releases containing HarfBuzz 4.4.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295429](https://bugs.openjdk.org/browse/JDK-8295429): Update harfbuzz md file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/292/head:pull/292` \
`$ git checkout pull/292`

Update a local copy of the PR: \
`$ git checkout pull/292` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 292`

View PR using the GUI difftool: \
`$ git pr show -t 292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/292.diff">https://git.openjdk.org/jdk15u-dev/pull/292.diff</a>

</details>
