### PR TITLE
8277881: Missing SessionID in TLS1.3 resumption in compatibility mode

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -568,15 +568,15 @@ final class ClientHello {
                             "No new session is allowed and " +
                             "no existing session can be resumed");
                 }
-
-                if (chc.maximumActiveProtocol.useTLS13PlusSpec() &&
-                        SSLConfiguration.useCompatibilityMode) {
-                    // In compatibility mode, the TLS 1.3 legacy_session_id
-                    // field MUST be non-empty, so a client not offering a
-                    // pre-TLS 1.3 session MUST generate a new 32-byte value.
-                    sessionId =
+            }
+            if (sessionId.length() == 0 &&
+                    chc.maximumActiveProtocol.useTLS13PlusSpec() &&
+                    SSLConfiguration.useCompatibilityMode) {
+                // In compatibility mode, the TLS 1.3 legacy_session_id
+                // field MUST be non-empty, so a client not offering a
+                // pre-TLS 1.3 session MUST generate a new 32-byte value.
+                sessionId =
                         new SessionId(true, chc.sslContext.getSecureRandom());
-                }
             }
 
             ProtocolVersion minimumVersion = ProtocolVersion.NONE;

--- a/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
@@ -97,7 +97,7 @@ final class SSLConfiguration implements Cloneable {
     static final boolean allowLegacyMasterSecret =
         Utilities.getBooleanProperty("jdk.tls.allowLegacyMasterSecret", true);
 
-    // Allow full handshake without Extended Master Secret extension.
+    // Use TLS1.3 middlebox compatibility mode.
     static final boolean useCompatibilityMode = Utilities.getBooleanProperty(
             "jdk.tls.client.useCompatibilityMode", true);
 

--- a/test/jdk/javax/net/ssl/SSLSession/ResumeTLS13withSNI.java
+++ b/test/jdk/javax/net/ssl/SSLSession/ResumeTLS13withSNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 /*
  * @test
- * @bug 8211806
+ * @bug 8211806 8277881
  * @summary TLS 1.3 handshake server name indication is missing on a session resume
  * @run main/othervm ResumeTLS13withSNI
  */
@@ -338,6 +338,9 @@ public class ResumeTLS13withSNI {
 
         // Get the legacy session length and skip that many bytes
         int sessIdLen = Byte.toUnsignedInt(resCliHello.get());
+        if (sessIdLen == 0) {
+            throw new Exception("SessionID field empty");
+        }
         resCliHello.position(resCliHello.position() + sessIdLen);
 
         // Skip over all the cipher suites


### PR DESCRIPTION
backporting for parity with LTS releases. Clean backport; all relevant tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277881](https://bugs.openjdk.org/browse/JDK-8277881): Missing SessionID in TLS1.3 resumption in compatibility mode


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/297/head:pull/297` \
`$ git checkout pull/297`

Update a local copy of the PR: \
`$ git checkout pull/297` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 297`

View PR using the GUI difftool: \
`$ git pr show -t 297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/297.diff">https://git.openjdk.org/jdk15u-dev/pull/297.diff</a>

</details>
