### PR TITLE
8294307: ISO 4217 Amendment 173 Update

### DIFF
--- a/make/data/currency/CurrencyData.properties
+++ b/make/data/currency/CurrencyData.properties
@@ -32,7 +32,7 @@ formatVersion=3
 # Version of the currency code information in this class.
 # It is a serial number that accompanies with each amendment.
 
-dataVersion=172
+dataVersion=173
 
 # List of all valid ISO 4217 currency codes.
 # To ensure compatibility, do not remove codes.

--- a/test/jdk/java/util/Currency/tablea1.txt
+++ b/test/jdk/java/util/Currency/tablea1.txt
@@ -1,12 +1,12 @@
 #
 #
-# Amendments up until ISO 4217 AMENDMENT NUMBER 172
-#   (As of 27 June 2022)
+# Amendments up until ISO 4217 AMENDMENT NUMBER 173
+#   (As of 23 September 2022)
 #
 
 # Version
 FILEVERSION=3
-DATAVERSION=172
+DATAVERSION=173
 
 # ISO 4217 currency data
 AF	AFN	971	2


### PR DESCRIPTION
this is a regular update I need to backport. Everything is clean and tests pass but src/java.base/share/data/currency/ is make/data/currency/ in older releases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294307](https://bugs.openjdk.org/browse/JDK-8294307): ISO 4217 Amendment 173 Update


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**)
 * [Andrew Brygin](https://openjdk.org/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/302/head:pull/302` \
`$ git checkout pull/302`

Update a local copy of the PR: \
`$ git checkout pull/302` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 302`

View PR using the GUI difftool: \
`$ git pr show -t 302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/302.diff">https://git.openjdk.org/jdk15u-dev/pull/302.diff</a>

</details>
