### PR TITLE
8290451: Incorrect result when switching to C2 OSR compilation from C1

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -771,7 +771,7 @@ void Canonicalizer::do_If(If* x) {
         else if (lss_sux == gtr_sux) { cond = If::neq; tsux = lss_sux; fsux = eql_sux; }
         else if (eql_sux == gtr_sux) { cond = If::geq; tsux = eql_sux; fsux = lss_sux; }
         else                         { ShouldNotReachHere();                           }
-        If* canon = new If(cmp->x(), cond, nan_sux == tsux, cmp->y(), tsux, fsux, cmp->state_before(), x->is_safepoint());
+        If* canon = new If(cmp->x(), cond, nan_sux == tsux, cmp->y(), tsux, fsux, x->state_before(), x->is_safepoint());
         if (cmp->x() == cmp->y()) {
           do_If(canon);
         } else {

--- a/test/hotspot/jtreg/compiler/c1/BadStateAtLongCmp.jasm
+++ b/test/hotspot/jtreg/compiler/c1/BadStateAtLongCmp.jasm
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+super public class BadStateAtLongCmp
+	version 52:0
+{
+  public static Field field:I;
+
+  public Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+
+  /* Same as:
+     public static void test() {
+        long l = 0;
+        do {
+            l++;
+            field++;
+        } while (l < 1000);
+     }
+     but with field++ between the lcmp and iflt bytecodes.
+   */
+  public static Method test:"()V"
+	stack 4 locals 2
+  {
+		lconst_0;
+		lstore_0;
+	L2:	stack_frame_type append;
+		locals_map long;
+		lload_0;
+		lconst_1;
+		ladd;
+		lstore_0;
+		lload_0;
+		ldc2_w	long 1000l;
+		lcmp;
+		getstatic	Field field:"I";
+		iconst_1;
+		iadd;
+		putstatic	Field field:"I";
+		iflt	L2;
+		return;
+  }
+
+} // end Class BadStateAtLongCmp

--- a/test/hotspot/jtreg/compiler/c1/TestBadStateAtLongCmp.java
+++ b/test/hotspot/jtreg/compiler/c1/TestBadStateAtLongCmp.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8290451
+ * @summary Incorrect result when switching to C2 OSR compilation from C1
+ * @compile BadStateAtLongCmp.jasm
+ * @run main/othervm -Xbatch TestBadStateAtLongCmp
+ */
+
+public class TestBadStateAtLongCmp {
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            BadStateAtLongCmp.test();
+        }
+        int expected = 20_000 * 1000;
+        if (BadStateAtLongCmp.field != expected) {
+            throw new RuntimeException("test failed: " + BadStateAtLongCmp.field + " != " + expected);
+        }
+    }
+}


### PR DESCRIPTION
Clean backport of a C2 change for parity with LTS releases. Compiler tests do pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290451](https://bugs.openjdk.org/browse/JDK-8290451): Incorrect result when switching to C2 OSR compilation from C1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/309/head:pull/309` \
`$ git checkout pull/309`

Update a local copy of the PR: \
`$ git checkout pull/309` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 309`

View PR using the GUI difftool: \
`$ git pr show -t 309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/309.diff">https://git.openjdk.org/jdk15u-dev/pull/309.diff</a>

</details>
