### PR TITLE
8261279: sun/util/resources/cldr/TimeZoneNamesTest.java timed out

### DIFF
--- a/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
+++ b/test/jdk/sun/util/resources/cldr/TimeZoneNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
  /*
  * @test
- * @bug 8181157 8202537 8234347 8236548
+ * @bug 8181157 8202537 8234347 8236548 8261279
  * @modules jdk.localedata
  * @summary Checks CLDR time zone names are generated correctly at runtime
  * @run testng/othervm -Djava.locale.providers=CLDR TimeZoneNamesTest
@@ -198,6 +198,7 @@ public class TimeZoneNamesTest {
     public void test_getZoneStrings() {
         assertFalse(
             Arrays.stream(Locale.getAvailableLocales())
+                .limit(30)
                 .peek(l -> System.out.println("Locale: " + l))
                 .map(l -> DateFormatSymbols.getInstance(l).getZoneStrings())
                 .flatMap(zs -> Arrays.stream(zs))


### PR DESCRIPTION
Backporting this useful test fix as such and as a prerequisite to the related changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8261279](https://bugs.openjdk.org/browse/JDK-8261279): sun/util/resources/cldr/TimeZoneNamesTest.java timed out


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/312/head:pull/312` \
`$ git checkout pull/312`

Update a local copy of the PR: \
`$ git checkout pull/312` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 312`

View PR using the GUI difftool: \
`$ git pr show -t 312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/312.diff">https://git.openjdk.org/jdk15u-dev/pull/312.diff</a>

</details>
