### PR TITLE
8287076: Document.normalizeDocument() produces different results

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttributeMap.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/AttributeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -39,7 +39,7 @@ import org.w3c.dom.Node;
  *
  * @xerces.internal
  *
- * @LastModified: Oct 2017
+ * @LastModified: June 2022
  */
 public class AttributeMap extends NamedNodeMapImpl {
 
@@ -117,7 +117,7 @@ public class AttributeMap extends NamedNodeMapImpl {
         } else {
             i = -1 - i; // Insert point (may be end of list)
             if (null == nodes) {
-                nodes = new ArrayList<>(5);
+                nodes = new ArrayList<>();
             }
             nodes.add(i, arg);
         }
@@ -193,7 +193,7 @@ public class AttributeMap extends NamedNodeMapImpl {
             } else {
                 i = -1 - i; // Insert point (may be end of list)
                 if (null == nodes) {
-                    nodes = new ArrayList<>(5);
+                    nodes = new ArrayList<>();
                 }
                 nodes.add(i, arg);
             }
@@ -591,7 +591,7 @@ public class AttributeMap extends NamedNodeMapImpl {
             else {
                 i = -1 - i; // Insert point (may be end of list)
                 if (null == nodes) {
-                    nodes = new ArrayList<>(5);
+                    nodes = new ArrayList<>();
                 }
                 nodes.add(i, arg);
             }

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/DOMNormalizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -89,7 +89,7 @@ import org.w3c.dom.Text;
  *
  * @author Elena Litani, IBM
  * @author Neeraj Bajaj, Sun Microsystems, inc.
- * @LastModified: Apr 2019
+ * @LastModified: June 2022
  */
 public class DOMNormalizer implements XMLDocumentHandler {
 
@@ -139,9 +139,6 @@ public class DOMNormalizer implements XMLDocumentHandler {
 
     /** Stores all namespace bindings on the current element */
     protected final NamespaceContext fLocalNSBinder = new NamespaceSupport();
-
-    /** list of attributes */
-    protected final List<Node> fAttributeList = new ArrayList<>(5);
 
     /** DOM Locator -  for namespace fixup algorithm */
     protected final DOMLocatorImpl fLocator = new DOMLocatorImpl();
@@ -885,9 +882,9 @@ public class DOMNormalizer implements XMLDocumentHandler {
         if (attributes != null) {
 
             // clone content of the attributes
-            attributes.cloneMap(fAttributeList);
-            for (int i = 0; i < fAttributeList.size(); i++) {
-                Attr attr = (Attr) fAttributeList.get(i);
+            List<Node> attrList = attributes.cloneMap(new ArrayList<>());
+            for (int i = 0; i < attrList.size(); i++) {
+                Attr attr = (Attr) attrList.get(i);
                 fLocator.fRelatedNode = attr;
 
                 if (DEBUG) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/dom/NamedNodeMapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -56,7 +56,7 @@ import org.w3c.dom.Node;
  * @xerces.internal
  *
  * @since  PR-DOM-Level-1-19980818.
- * @LastModified: Jan 2018
+ * @LastModified: June 2022
  */
 public class NamedNodeMapImpl
     implements NamedNodeMap, Serializable {
@@ -196,7 +196,7 @@ public class NamedNodeMapImpl
         } else {
             i = -1 - i; // Insert point (may be end of list)
             if (null == nodes) {
-                nodes = new ArrayList<>(5);
+                nodes = new ArrayList<>();
             }
             nodes.add(i, arg);
         }
@@ -246,7 +246,7 @@ public class NamedNodeMapImpl
             } else {
                 i = -1 - i; // Insert point (may be end of list)
                 if (null == nodes) {
-                    nodes = new ArrayList<>(5);
+                    nodes = new ArrayList<>();
                 }
                 nodes.add(i, arg);
             }
@@ -561,7 +561,7 @@ public class NamedNodeMapImpl
             else {
                 i = -1 - i; // Insert point (may be end of list)
                 if (null == nodes) {
-                    nodes = new ArrayList<>(5);
+                    nodes = new ArrayList<>();
                 }
                 nodes.add(i, arg);
             }


### PR DESCRIPTION
backporting for parity with LTS releases.
Clean backport with only copyright difference. jaxp and jdk/java/xml tests run OK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287076](https://bugs.openjdk.org/browse/JDK-8287076): Document.normalizeDocument() produces different results


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/313/head:pull/313` \
`$ git checkout pull/313`

Update a local copy of the PR: \
`$ git checkout pull/313` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 313`

View PR using the GUI difftool: \
`$ git pr show -t 313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/313.diff">https://git.openjdk.org/jdk15u-dev/pull/313.diff</a>

</details>
