### PR TITLE
8273894: ConcurrentModificationException raised every time ReferralsCache drops referral

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReferralsCache.java
@@ -27,6 +27,7 @@ package sun.security.krb5.internal;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -148,10 +149,11 @@ final class ReferralsCache {
         Date now = new Date();
         Map<String, ReferralCacheEntry> entries = referralsMap.get(k);
         if (entries != null) {
-            for (Entry<String, ReferralCacheEntry> mapEntry :
-                    entries.entrySet()) {
+            Iterator<Entry<String, ReferralCacheEntry>> it = entries.entrySet().iterator();
+            while (it.hasNext()) {
+                Entry<String, ReferralCacheEntry> mapEntry = it.next();
                 if (mapEntry.getValue().getCreds().getEndTime().before(now)) {
-                    entries.remove(mapEntry.getKey());
+                    it.remove();
                 }
             }
         }


### PR DESCRIPTION
backporting for parity with LTS releases. Clean backport, security tests do pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273894](https://bugs.openjdk.org/browse/JDK-8273894): ConcurrentModificationException raised every time ReferralsCache drops referral


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk15u-dev pull/315/head:pull/315` \
`$ git checkout pull/315`

Update a local copy of the PR: \
`$ git checkout pull/315` \
`$ git pull https://git.openjdk.org/jdk15u-dev pull/315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 315`

View PR using the GUI difftool: \
`$ git pr show -t 315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk15u-dev/pull/315.diff">https://git.openjdk.org/jdk15u-dev/pull/315.diff</a>

</details>
